### PR TITLE
Fix: fully remove API key from subprocess env

### DIFF
--- a/src/services/claude_subprocess.py
+++ b/src/services/claude_subprocess.py
@@ -515,7 +515,7 @@ async def _execute_subprocess_once(
             script,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env={**os.environ, "ANTHROPIC_API_KEY": ""},  # Unset to use subscription
+            env={k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"},
         )
         logger.debug(f"Subprocess created with PID: {process.pid}")
 

--- a/src/services/llm_service.py
+++ b/src/services/llm_service.py
@@ -27,19 +27,14 @@ class LLMService:
         self._setup_api_keys()
 
     def _setup_api_keys(self) -> None:
-        """Setup API keys for various LLM providers"""
-        # OpenAI
-        if api_key := os.getenv("OPENAI_API_KEY"):
-            os.environ["OPENAI_API_KEY"] = api_key
+        """Verify API keys are available for LLM providers.
 
-        # Add more providers as needed
-        # Anthropic
-        if api_key := os.getenv("ANTHROPIC_API_KEY"):
-            os.environ["ANTHROPIC_API_KEY"] = api_key
-
-        # Google
-        if api_key := os.getenv("GOOGLE_API_KEY"):
-            os.environ["GOOGLE_API_KEY"] = api_key
+        LiteLLM reads keys directly from os.environ at call time,
+        so no re-assignment is needed.
+        """
+        for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"):
+            if os.getenv(key):
+                logger.debug("LLM provider key available: %s", key)
 
     async def analyze_image(
         self,

--- a/src/services/session_naming.py
+++ b/src/services/session_naming.py
@@ -126,7 +126,7 @@ async def generate_session_name(prompt: str) -> str:
             script,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env={**os.environ, "ANTHROPIC_API_KEY": ""},
+            env={k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"},
         )
 
         stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)

--- a/tests/test_services/test_claude_subprocess.py
+++ b/tests/test_services/test_claude_subprocess.py
@@ -980,9 +980,9 @@ class TestExecuteClaudeSubprocessEnvironment:
                 ):
                     pass
 
-            # ANTHROPIC_API_KEY should be empty string
+            # ANTHROPIC_API_KEY should be fully removed (not just empty)
             assert len(captured_env) == 1
-            assert captured_env[0].get("ANTHROPIC_API_KEY") == ""
+            assert "ANTHROPIC_API_KEY" not in captured_env[0]
 
 
 class TestExecuteClaudeSubprocessExceptionHandling:


### PR DESCRIPTION
## Summary
- Remove `ANTHROPIC_API_KEY` from subprocess environment entirely instead of setting it to `""`, which could confuse code that checks for key presence
- Remove redundant self-assignment of env vars in `LLMService._setup_api_keys()` (reading from env and writing back is a no-op)
- Update test assertion to verify key absence rather than empty string

## Test plan
- [ ] Run `pytest tests/test_services/test_claude_subprocess.py -v` to confirm updated assertion passes
- [ ] Verify Claude subprocess calls work correctly without the key in env

🤖 Generated with [Claude Code](https://claude.com/claude-code)