### PR TITLE
style: black format test_webhook.py

### DIFF
--- a/tests/test_api/test_webhook.py
+++ b/tests/test_api/test_webhook.py
@@ -90,9 +90,7 @@ class TestVerifyAdminKey:
         with patch("src.api.webhook.get_admin_api_key") as mock_get_key:
             mock_get_key.return_value = "valid_key_hash"
 
-            result = await verify_admin_key(
-                self._mock_request(), "valid_key_hash"
-            )
+            result = await verify_admin_key(self._mock_request(), "valid_key_hash")
 
             assert result is True
 


### PR DESCRIPTION
## Summary
- Fix black formatting issue in `test_webhook.py` that caused CI lint failure on PR #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)