### PR TITLE
fix: remove duplicate update parameter in handle_claude_callback

### DIFF
--- a/src/bot/callback_handlers.py
+++ b/src/bot/callback_handlers.py
@@ -1235,7 +1235,6 @@ async def handle_claude_callback(
     context: ContextTypes.DEFAULT_TYPE = None,
     update: Update = None,
     locale: str = None,
-    update: "Update" = None,
 ) -> None:
     """Handle Claude Code session callbacks."""
     from ..services.claude_code_service import (


### PR DESCRIPTION
## Summary
- Removes duplicate `update` parameter in `handle_claude_callback()` function definition (F831 lint error)
- Was causing CI lint failure on main

## Test plan
- [x] flake8 passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)