### PR TITLE
fix: update API key test to match new exclusion approach

### DIFF
--- a/tests/test_p0_fixes.py
+++ b/tests/test_p0_fixes.py
@@ -115,12 +115,16 @@ class TestApiKeyNotManipulated:
         assert not hasattr(service, "_api_key_lock")
 
     def test_subprocess_unsets_key_in_env(self):
-        """claude_subprocess.py should unset ANTHROPIC_API_KEY in subprocess env."""
+        """claude_subprocess.py should exclude ANTHROPIC_API_KEY from subprocess env."""
         from pathlib import Path
 
         subprocess_file = Path("src/services/claude_subprocess.py").read_text()
         assert "ANTHROPIC_API_KEY" in subprocess_file
-        assert '"ANTHROPIC_API_KEY": ""' in subprocess_file
+        # Key is excluded via dict comprehension filter or os.environ.pop
+        assert (
+            'k != "ANTHROPIC_API_KEY"' in subprocess_file
+            or 'pop("ANTHROPIC_API_KEY"' in subprocess_file
+        )
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Updates `test_subprocess_unsets_key_in_env` to match the current code which excludes `ANTHROPIC_API_KEY` via dict comprehension filter + `os.environ.pop()` instead of setting it to empty string
- Fixes CI failure introduced after commit 4de0bac

## Test plan
- [x] Test passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)