### PR TITLE
fix: disable enrich_with_images when Google keys unavailable

### DIFF
--- a/scripts/proactive_tasks/task_registry.yaml
+++ b/scripts/proactive_tasks/task_registry.yaml
@@ -52,7 +52,7 @@ tasks:
         - "Grep"
 
       # Output settings
-      enrich_with_images: true
+      enrich_with_images: false  # Requires GOOGLE_API_KEY + GOOGLE_SEARCH_CX
       image_count: 3
       generate_pdf: true
       pdf_mobile_friendly: true


### PR DESCRIPTION
## Summary
- Disables `enrich_with_images` in the AI coding tools research task config since `GOOGLE_API_KEY`/`GOOGLE_SEARCH_CX` are not available
- The task's own `validate_config()` was still blocking on these credentials even after task_runner made them optional

## Test plan
- [x] Task now starts successfully with optional warning about missing Google keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)