### PR TITLE
fix: P1 memory leaks — session dict pruning, paginated queries, temp cleanup (#117)

### DIFF
--- a/src/services/claude_code_service.py
+++ b/src/services/claude_code_service.py
@@ -803,6 +803,9 @@ WORKFLOW for creating notes:
     async def end_session(self, chat_id: int) -> bool:
         """End the active session for a chat."""
         session_id = self.active_sessions.pop(chat_id, None)
+        self._timeout_sessions.pop(chat_id, None)
+        self._pending_sessions.pop(chat_id, None)
+        self._pending_session_ids.pop(chat_id, None)
 
         if session_id:
             async with get_db_session() as session:


### PR DESCRIPTION
## Summary
- **Session dict pruning**: `end_session()` now clears `_timeout_sessions`, `_pending_sessions`, `_pending_session_ids` for the chat
- **Paginated GDPR export**: `/mydata` uses `COUNT()` for totals + `LIMIT 10000` for records to prevent OOM
- **Batched image deletion**: `/deletedata` loads images in batches of 500 instead of all at once
- **Temp video cleanup**: Per-request unique temp dir + `shutil.rmtree` in finally block

Closes #117

## Test plan
- [x] 507 tests pass
- [x] Lint clean (black, isort)
- [ ] Manual: `/mydata` returns correct counts with large data
- [ ] Manual: video processing leaves no orphaned temp dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)