### PR TITLE
fix: wire retry.py into external service calls (#118)

### DIFF
--- a/src/utils/retry.py
+++ b/src/utils/retry.py
@@ -25,6 +25,12 @@ DEFAULT_RETRY_EXCEPTIONS: tuple = (
 )
 
 
+class RetryableError(Exception):
+    """Signal a transient failure that should be retried."""
+
+    pass
+
+
 class RetryConfig:
     """Configuration for retry behavior."""
 

--- a/tests/test_bot/test_handlers/test_base.py
+++ b/tests/test_bot/test_handlers/test_base.py
@@ -99,16 +99,17 @@ class TestTelegramApiSync:
     @patch("src.bot.handlers.base.run_python_script")
     @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "test_token"})
     def test_run_telegram_api_sync_failure(self, mock_run):
-        """Failed API call returns None."""
+        """Failed subprocess raises RetryableError after exhausting retries."""
         from src.bot.handlers.base import _run_telegram_api_sync
+        from src.utils.retry import RetryableError
 
         mock_result = MagicMock()
         mock_result.success = False
-        mock_result.stderr = "Network error"
+        mock_result.error = "Network error"
         mock_run.return_value = mock_result
 
-        result = _run_telegram_api_sync("sendMessage", {"chat_id": 1, "text": "hi"})
-        assert result is None
+        with pytest.raises(RetryableError):
+            _run_telegram_api_sync("sendMessage", {"chat_id": 1, "text": "hi"})
 
     @patch("src.bot.handlers.base.run_python_script")
     @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "test_token"})

--- a/tests/test_services/test_stt_fallback.py
+++ b/tests/test_services/test_stt_fallback.py
@@ -304,7 +304,9 @@ class TestGroqProvider:
                 )
 
     def test_groq_api_error(self, stt_service, audio_path):
-        """Groq provider should handle API errors gracefully."""
+        """Groq provider should raise RetryableError on API errors."""
+        from src.utils.retry import RetryableError
+
         mock_subprocess_result = MagicMock()
         mock_subprocess_result.success = False
         mock_subprocess_result.stderr = "Rate limit exceeded"
@@ -317,10 +319,8 @@ class TestGroqProvider:
             ),
             patch.dict(os.environ, {"GROQ_API_KEY": "test-groq-key"}),
         ):
-            result = stt_service._transcribe_groq(audio_path)
-
-            assert result.success is False
-            assert result.provider == "groq"
+            with pytest.raises(RetryableError):
+                stt_service._transcribe_groq(audio_path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Wire existing `src/utils/retry.py` (`@retry` / `@async_retry` decorators) into 5 service modules — previously imported by zero modules
- Add `RetryableError` exception class for services to signal transient failures
- Telegram API sends (base.py, subprocess_helper.py) now retry on 429 rate limit and 5xx server errors
- LiteLLM image analysis retries on transient API errors via extracted `_call_llm` method
- Groq Whisper STT retries once before falling back to local whisper
- Bot initialization in main.py uses `@async_retry` instead of ad-hoc for-loop

## Files Changed
- `src/utils/retry.py` — Added `RetryableError` exception
- `src/bot/handlers/base.py` — `@retry` on `_run_telegram_api_sync`
- `src/services/llm_service.py` — `@async_retry` on new `_call_llm` method
- `src/services/stt_service.py` — `@retry` on `_transcribe_groq`
- `src/utils/subprocess_helper.py` — `@retry` on `send_telegram_message`
- `src/main.py` — `@async_retry` replacing ad-hoc retry loop
- Tests: 4 new retry tests, 2 updated for new behavior

## Test plan
- [x] All 3286 tests pass (6 deselected — pre-existing failures)
- [x] 24 retry-specific tests pass (20 existing + 4 new)
- [x] Linting clean (black, isort, flake8)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)