### PR TITLE
refactor: unify configuration system into config.py (#150)

### DIFF
--- a/src/bot/handlers/voice_settings_commands.py
+++ b/src/bot/handlers/voice_settings_commands.py
@@ -1597,7 +1597,7 @@ async def partner_test_voice_handler(
         )
 
         # Get voice config from personality
-        from ...core.defaults_loader import get_config_value
+        from ...core.config import get_config_value
 
         personalities = get_config_value("accountability.personalities", {})
         personality_config = personalities.get(personality, personalities["supportive"])

--- a/src/core/defaults_loader.py
+++ b/src/core/defaults_loader.py
@@ -1,197 +1,56 @@
 """
-Defaults loader for configuration from YAML files.
+Backward-compatibility shim -- all functionality moved to src.core.config.
 
-Provides a hierarchical configuration system:
-1. config/defaults.yaml - Base defaults (checked into repo)
-2. config/settings.yaml - User overrides (gitignored)
-3. Environment variables - Final override (highest priority)
+Import from src.core.config instead.
 """
 
-import os
 from pathlib import Path
-from typing import Any, Dict, Optional
 
-import yaml
-
-# Cache for loaded config
-_config_cache: Optional[Dict[str, Any]] = None
-_config_path: Optional[Path] = None
+from .config import (
+    PROJECT_ROOT,
+    clear_cache,
+    deep_merge,
+    expand_path,
+    get_api_url,
+    get_config_value,
+    get_limit,
+    get_message,
+    get_model,
+    get_nested,
+    get_path,
+    get_reaction,
+    get_timeout,
+    load_defaults,
+    load_yaml_config,
+)
 
 
 def get_project_root() -> Path:
     """Get the project root directory."""
-    # Navigate up from src/core/defaults_loader.py
-    return Path(__file__).parent.parent.parent
+    return PROJECT_ROOT
 
 
-def load_yaml_file(file_path: Path) -> Dict[str, Any]:
-    """Load a YAML file and return its contents as a dictionary."""
-    if not file_path.exists():
-        return {}
-
-    with open(file_path, "r", encoding="utf-8") as f:
-        content = yaml.safe_load(f)
-        return content if content else {}
+def load_yaml_file(file_path) -> dict:
+    """Backward compat -- delegates to config.load_yaml_config."""
+    return load_yaml_config(
+        Path(file_path) if not isinstance(file_path, Path) else file_path
+    )
 
 
-def deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
-    """Deep merge two dictionaries, with override taking precedence."""
-    result = base.copy()
-
-    for key, value in override.items():
-        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-            result[key] = deep_merge(result[key], value)
-        else:
-            result[key] = value
-
-    return result
-
-
-def expand_path(path: str) -> str:
-    """Expand ~ and environment variables in a path."""
-    if not path:
-        return path
-    return os.path.expanduser(os.path.expandvars(path))
-
-
-def get_nested(config: Dict[str, Any], key_path: str, default: Any = None) -> Any:
-    """
-    Get a nested value from config using dot notation.
-
-    Example:
-        get_nested(config, "timeouts.claude_query_timeout", 300)
-    """
-    keys = key_path.split(".")
-    value = config
-
-    for key in keys:
-        if isinstance(value, dict) and key in value:
-            value = value[key]
-        else:
-            return default
-
-    return value
-
-
-def load_defaults(
-    defaults_path: Optional[Path] = None,
-    settings_path: Optional[Path] = None,
-    reload: bool = False,
-) -> Dict[str, Any]:
-    """
-    Load configuration from YAML files.
-
-    Args:
-        defaults_path: Path to defaults.yaml (optional, uses project default)
-        settings_path: Path to settings.yaml (optional, uses project default)
-        reload: Force reload even if cached
-
-    Returns:
-        Merged configuration dictionary
-    """
-    global _config_cache, _config_path
-
-    project_root = get_project_root()
-
-    if defaults_path is None:
-        defaults_path = project_root / "config" / "defaults.yaml"
-
-    if settings_path is None:
-        settings_path = project_root / "config" / "settings.yaml"
-
-    # Return cached config if available and not forcing reload
-    if not reload and _config_cache is not None and _config_path == defaults_path:
-        return _config_cache
-
-    # Load base defaults
-    config = load_yaml_file(defaults_path)
-
-    # Merge user settings (if exists)
-    user_settings = load_yaml_file(settings_path)
-    if user_settings:
-        config = deep_merge(config, user_settings)
-
-    # Cache the result
-    _config_cache = config
-    _config_path = defaults_path
-
-    return config
-
-
-def get_config_value(
-    key_path: str,
-    default: Any = None,
-    expand_paths: bool = False,
-) -> Any:
-    """
-    Get a configuration value using dot notation.
-
-    Args:
-        key_path: Dot-separated path like "timeouts.claude_query_timeout"
-        default: Default value if key not found
-        expand_paths: If True and value is a string, expand ~ and env vars
-
-    Returns:
-        Configuration value or default
-    """
-    config = load_defaults()
-    value = get_nested(config, key_path, default)
-
-    if expand_paths and isinstance(value, str):
-        value = expand_path(value)
-
-    return value
-
-
-# Convenience functions for common config sections
-def get_timeout(name: str, default: float = 30.0) -> float:
-    """Get a timeout value from config."""
-    return float(get_config_value(f"timeouts.{name}", default))
-
-
-def get_limit(name: str, default: int = 100) -> int:
-    """Get a limit value from config."""
-    return int(get_config_value(f"limits.{name}", default))
-
-
-def get_path(name: str, default: str = "") -> str:
-    """Get an expanded path from config."""
-    return get_config_value(f"paths.{name}", default, expand_paths=True)
-
-
-def get_model(name: str, default: str = "") -> str:
-    """Get a model name from config."""
-    return get_config_value(f"models.{name}", default)
-
-
-def get_message(name: str, default: str = "", **kwargs: Any) -> str:
-    """Get a message template, delegating to the i18n framework.
-
-    Backward-compatible: callers that used get_message("error_prefix")
-    now get the value from locales/en.yaml under messages.error_prefix.
-    Falls back to config/defaults.yaml if the i18n key is missing.
-    """
-    from .i18n import t
-
-    result = t(f"messages.{name}", "en", **kwargs)
-    # If t() returned the raw key (missing), fall back to config
-    if result == f"messages.{name}":
-        return get_config_value(f"messages.{name}", default)
-    return result
-
-
-def get_reaction(name: str, default: str = "") -> str:
-    """Get a reaction emoji from config."""
-    return get_config_value(f"reactions.{name}", default)
-
-
-def get_api_url(name: str, default: str = "") -> str:
-    """Get an API URL from config."""
-    return get_config_value(f"api.{name}", default)
-
-
-def clear_cache() -> None:
-    """Clear the configuration cache (useful for testing)."""
-    global _config_cache, _config_path
-    _config_cache = None
-    _config_path = None
+__all__ = [
+    "clear_cache",
+    "deep_merge",
+    "expand_path",
+    "get_api_url",
+    "get_config_value",
+    "get_limit",
+    "get_message",
+    "get_model",
+    "get_nested",
+    "get_path",
+    "get_project_root",
+    "get_reaction",
+    "get_timeout",
+    "load_defaults",
+    "load_yaml_file",
+]

--- a/src/main.py
+++ b/src/main.py
@@ -799,7 +799,7 @@ _updates_lock = asyncio.Lock()
 def _get_update_limits():
     """Load update dedup limits from config (lazy, avoids import-time YAML reads)."""
     try:
-        from src.core.defaults_loader import get_nested, load_defaults
+        from src.core.config import get_nested, load_defaults
 
         cfg = load_defaults()
         return (

--- a/src/services/accountability_service.py
+++ b/src/services/accountability_service.py
@@ -12,8 +12,8 @@ from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import select
 
+from ..core.config import get_config_value
 from ..core.database import get_db_session
-from ..core.defaults_loader import get_config_value
 from ..core.i18n import t
 from ..models.tracker import CheckIn, Tracker
 from ..models.user_settings import UserSettings


### PR DESCRIPTION
## Summary
- Merge `defaults_loader.py` features into `config.py` — single source of truth for all configuration
- Clear 4-level precedence: `defaults.yaml → settings.yaml → profile YAML → env vars`
- Remove duplicate `deep_merge()` implementation
- Port convenience functions (`get_timeout`, `get_message`, `get_limit`, etc.) to `config.py`
- `defaults_loader.py` becomes a thin backward-compat shim re-exporting from `config.py`

## Files Changed
- `src/core/config.py` — Added `expand_path`, `get_nested`, `clear_cache`, `load_defaults`, convenience functions; updated `get_config_value` with `expand_paths` param; updated `load_profile_config` to load `settings.yaml`
- `src/core/defaults_loader.py` — Replaced with backward-compat shim (~55 lines)
- `src/services/accountability_service.py` — Import from `config` instead of `defaults_loader`
- `src/bot/handlers/voice_settings_commands.py` — Import from `config` instead of `defaults_loader`
- `src/main.py` — Import from `config` instead of `defaults_loader`

## Test plan
- [x] All 47 `test_defaults_loader.py` tests pass through the shim
- [x] 3282 tests pass across full suite
- [x] Zero new failures introduced
- [x] Linting clean (black, isort, flake8)

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)