### PR TITLE
fix: add missing commands to Telegram BotCommand autocomplete (#121)

### DIFF
--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -636,6 +636,7 @@ class TelegramBot:
 
         commands = [
             # Core
+            BotCommand("start", "Start the bot / show welcome"),
             BotCommand("help", "Show help and available commands"),
             BotCommand("menu", "Browse all commands by category"),
             BotCommand("settings", "Bot settings and preferences"),
@@ -644,17 +645,28 @@ class TelegramBot:
             BotCommand("session", "Manage Claude sessions"),
             BotCommand("meta", "Claude prompt in bot project dir"),
             BotCommand("research", "Deep web research with Claude"),
+            BotCommand("tasks", "List Claude Code background tasks"),
+            BotCommand("opencode", "Send prompt to OpenCode agent"),
             # Collect
             BotCommand("collect", "Batch collect items for processing"),
+            BotCommand("coco", "Start collect mode (shortcut)"),
             # Notes & Review
             BotCommand("note", "View an Obsidian vault note"),
             BotCommand("review", "SRS — review due cards"),
+            BotCommand("srs_stats", "SRS learning statistics"),
             BotCommand("trail", "Review a vault trail"),
             # Image modes
             BotCommand("mode", "Show or change image analysis mode"),
             BotCommand("analyze", "Art critique mode"),
             BotCommand("coach", "Photo coaching mode"),
+            BotCommand("creative", "Creative image analysis mode"),
+            BotCommand("quick", "Quick image analysis mode"),
+            BotCommand("formal", "Formal image analysis mode"),
+            BotCommand("tags", "Image tagging mode"),
             BotCommand("gallery", "Browse processed images"),
+            # Tracker
+            BotCommand("track", "Daily habit tracker"),
+            BotCommand("streak", "View tracking streaks"),
             # Polls
             BotCommand("polls", "Poll management"),
             # Privacy

--- a/src/bot/handlers/formatting.py
+++ b/src/bot/handlers/formatting.py
@@ -286,10 +286,13 @@ def markdown_to_telegram_html(text: str, include_frontmatter: bool = True) -> st
     def format_wikilink(match):
         import urllib.parse
 
+        from ...core.config import get_config_value
+
         note_name = match.group(1)
         display_name = note_name.lstrip("@")
         encoded_name = urllib.parse.quote(display_name, safe="")
-        deep_link = f"https://t.me/toolbuildingape_bot?start=note_{encoded_name}"
+        bot_username = get_config_value("bot.bot_username", "toolbuildingape_bot")
+        deep_link = f"https://t.me/{bot_username}?start=note_{encoded_name}"
         return f'<a href="{deep_link}">📄 {display_name}</a>'
 
     text = re.sub(r"\[\[([^\]]+)\]\]", format_wikilink, text)


### PR DESCRIPTION
## Summary
- Add 11 missing commands to BotCommand autocomplete list (`/start`, `/creative`, `/quick`, `/formal`, `/tags`, `/coco`, `/track`, `/streak`, `/tasks`, `/opencode`, `/srs_stats`)
- Replace hardcoded `toolbuildingape_bot` username in `formatting.py` with config lookup from `bot.bot_username`

## Test plan
- [x] All 490 bot tests pass
- [x] Linting clean

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)