### PR TITLE
fix: sanitize user-facing error messages (#123)

### DIFF
--- a/tests/test_bot/test_message_handlers.py
+++ b/tests/test_bot/test_message_handlers.py
@@ -1440,10 +1440,12 @@ class TestErrorHandling:
 
                     await handle_image_message(mock_update, mock_context)
 
-                    # Verify error message was shown
+                    # Verify user-friendly error message was shown
                     processing_msg.edit_text.assert_called()
                     call_args = processing_msg.edit_text.call_args[0][0]
-                    assert "Error" in call_args or "error" in call_args.lower()
+                    assert (
+                        "wrong" in call_args.lower() or "try again" in call_args.lower()
+                    )
 
     @pytest.mark.asyncio
     async def test_authentication_error_shows_specific_message(


### PR DESCRIPTION
## Summary
- Replace raw exception strings in contact/voice/image error messages with user-friendly text
- Read DEBUG_MODE from `get_settings().debug` instead of `os.getenv("DEBUG")`
- Technical details preserved in server-side `logger.error()` calls
- Added TODO for unsupported media types (stickers, animations, polls)

## Files Changed
- `src/bot/message_handlers.py` — sanitized 3 error messages, replaced DEBUG_MODE global with lazy config function
- `tests/test_bot/test_message_handlers.py` — updated assertion to match new wording

## Test plan
- [x] All 490 bot tests pass
- [x] Linting clean

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)