### PR TITLE
fix: auto-format Python files and add formatting hook

### DIFF
--- a/src/bot/handlers/claude_commands.py
+++ b/src/bot/handlers/claude_commands.py
@@ -398,9 +398,7 @@ async def _claude_reset(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
                     logger.warning(f"Invalid PID skipped: {pid[:20]}")
                     continue
                 try:
-                    subprocess.run(
-                        ["kill", "-15", pid], capture_output=True, timeout=5
-                    )
+                    subprocess.run(["kill", "-15", pid], capture_output=True, timeout=5)
                     killed_processes += 1
                     logger.info(f"Killed stuck Claude process: {pid}")
                 except Exception as e:


### PR DESCRIPTION
## Summary
- Fix black formatting in `claude_commands.py` that was failing CI on every deploy
- Add PostToolUse hook (`.claude/hooks/auto-format-python.sh`) that auto-runs `black` + `isort` on every edited Python file, preventing future CI lint failures

## How it works
The hook fires on every `Edit`/`Write` tool use. If the target is a `.py` file under `src/` or `tests/`, it runs `black --quiet` and `isort --quiet` on that file automatically. This means all Python files are always formatted before commit.

## Test plan
- [x] `black --check src/ tests/` passes with 0 files to reformat
- [x] Hook registered in `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)