### PR TITLE
fix: repair 5 CI test failures

### DIFF
--- a/tests/test_services/test_claude_timeout_fixes.py
+++ b/tests/test_services/test_claude_timeout_fixes.py
@@ -131,26 +131,25 @@ class TestConfigurableTimeout:
         # Default should be 30 minutes (1800 seconds)
         assert settings.claude_session_timeout_seconds == 1800
 
-    @pytest.mark.asyncio
-    async def test_custom_timeout_used_in_subprocess(self):
+    def test_custom_timeout_used_in_subprocess(self):
         """Test that custom timeout from settings is used."""
-        # This is an integration test - we verify the constant is used
-        from src.services.claude_subprocess import CLAUDE_SESSION_TIMEOUT_SECONDS
+        from src.services.claude_subprocess import get_session_timeout
 
         # Default should be 30 minutes
-        assert CLAUDE_SESSION_TIMEOUT_SECONDS == 1800
+        assert get_session_timeout() == 1800
 
     def test_per_message_timeout_separate_from_session_timeout(self):
         """Test that per-message timeout is separate from session timeout."""
         from src.services.claude_subprocess import (
-            CLAUDE_SESSION_TIMEOUT_SECONDS,
             CLAUDE_TIMEOUT_SECONDS,
+            get_session_timeout,
         )
 
+        session_timeout = get_session_timeout()
         # Per-message timeout should be much shorter than session timeout
-        assert CLAUDE_TIMEOUT_SECONDS < CLAUDE_SESSION_TIMEOUT_SECONDS
+        assert CLAUDE_TIMEOUT_SECONDS < session_timeout
         assert CLAUDE_TIMEOUT_SECONDS == 300  # 5 minutes
-        assert CLAUDE_SESSION_TIMEOUT_SECONDS == 1800  # 30 minutes
+        assert session_timeout == 1800  # 30 minutes
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fix 2 `test_claude_timeout_fixes` failures: tests imported non-existent `CLAUDE_SESSION_TIMEOUT_SECONDS` constant — replaced with `get_session_timeout()` function which is the actual implementation
- Fix 3 `test_image_service` failures: tests mocked the Telegram `bot` object but `_download_image()` uses subprocess isolation via `download_telegram_file()` — added proper subprocess mock
- Remove unused `telegram.File` import

## Root causes
1. **Timeout tests**: `CLAUDE_SESSION_TIMEOUT_SECONDS` was refactored from a module constant to a dynamic `get_session_timeout()` function (reads from settings), but tests weren't updated
2. **Image tests**: `_download_image()` was refactored to use subprocess isolation (`download_telegram_file`), bypassing the `bot` mock entirely. Tests needed to mock the subprocess helper instead.

## Prevention
Added two Claude Code hooks (local, in `.claude/`):
- **`auto-format-python.sh`** (PostToolUse) — auto-runs `black` + `isort` on every edited `.py` file
- **`pre-commit-tests.sh`** (PreToolUse) — runs full test suite before any `git commit`, blocking commit on failure

## Test plan
- [x] All 5 previously failing tests now pass
- [x] Full suite: 3292 passed, 0 failed
- [x] Lint clean (matches CI config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)