### PR TITLE
refactor: extract Telegram API utils from handler layer

### DIFF
--- a/src/services/heartbeat_service.py
+++ b/src/services/heartbeat_service.py
@@ -422,7 +422,7 @@ class HeartbeatService:
 
         # Format and send
         msg = self._format_message(result)
-        from ..bot.handlers.base import send_message_sync
+        from ..utils.telegram_api import send_message_sync
 
         send_message_sync(chat_id, msg, parse_mode="HTML")
 

--- a/src/services/life_weeks_scheduler.py
+++ b/src/services/life_weeks_scheduler.py
@@ -11,9 +11,9 @@ from datetime import datetime, time
 from sqlalchemy import select
 from telegram.ext import Application, ContextTypes
 
-from ..bot.handlers.base import send_photo_sync
 from ..core.database import get_db_session
 from ..models.user_settings import UserSettings
+from ..utils.telegram_api import send_photo_sync
 from .life_weeks_image import calculate_weeks_lived, generate_life_weeks_grid
 
 logger = logging.getLogger(__name__)

--- a/src/services/poll_scheduler.py
+++ b/src/services/poll_scheduler.py
@@ -100,7 +100,7 @@ _config: Optional[PollSchedulerConfig] = None
 
 async def _startup_expire_callback(context):
     """Clean up a poll that expired during bot downtime."""
-    from ..bot.handlers.base import _run_telegram_api_sync
+    from ..utils.telegram_api import _run_telegram_api_sync
     from .poll_lifecycle import get_poll_lifecycle_tracker
 
     poll_data = context.job.data

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility modules for the Telegram Agent."""
 
-from . import retry, subprocess_helper, task_tracker, tool_check
+from . import retry, subprocess_helper, task_tracker, telegram_api, tool_check
 
-__all__ = ["task_tracker", "subprocess_helper", "retry", "tool_check"]
+__all__ = ["task_tracker", "subprocess_helper", "retry", "telegram_api", "tool_check"]

--- a/src/utils/telegram_api.py
+++ b/src/utils/telegram_api.py
@@ -1,0 +1,187 @@
+"""
+Telegram Bot API utilities — subprocess-isolated sync callers.
+
+Moved from src/bot/handlers/base.py so that service-layer code can call
+Telegram without importing upward from the handler layer.
+
+Functions:
+- _run_telegram_api_sync(method, payload) — core HTTP caller via subprocess
+- send_message_sync(chat_id, text, ...)   — send a message
+- edit_message_sync(chat_id, message_id, text, ...) — edit a message
+- send_photo_sync(chat_id, photo_path, ...) — send a photo
+"""
+
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from .retry import RetryableError, retry
+from .subprocess_helper import run_python_script
+
+logger = logging.getLogger(__name__)
+
+
+@retry(max_attempts=3, base_delay=1.0, exceptions=(RetryableError,))
+def _run_telegram_api_sync(method: str, payload: dict) -> Optional[dict]:
+    """Call Telegram Bot API using secure subprocess (bypasses async blocking)."""
+    bot_token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    if not bot_token:
+        logger.error("TELEGRAM_BOT_TOKEN not set")
+        return None
+
+    try:
+        script = """
+import sys
+import json
+import os
+import requests
+
+# Read payload from stdin
+data = json.load(sys.stdin)
+method = data["method"]
+payload = data["payload"]
+
+# Get token from environment (not interpolated in script)
+bot_token = os.environ["TELEGRAM_BOT_TOKEN"]
+
+r = requests.post(
+    f"https://api.telegram.org/bot{bot_token}/{method}",
+    json=payload,
+    timeout=30
+)
+result = r.json()
+if result.get("ok"):
+    print(json.dumps({"success": True, "result": result["result"]}))
+else:
+    print(json.dumps({"success": False, "error": result}))
+"""
+        result = run_python_script(
+            script=script,
+            input_data={"method": method, "payload": payload},
+            env_vars={"TELEGRAM_BOT_TOKEN": bot_token},
+            timeout=60,
+        )
+
+        if result.success:
+            response = json.loads(result.stdout)
+            if response.get("success"):
+                return response.get("result")
+            else:
+                error = response.get("error", {})
+                error_code = (
+                    error.get("error_code", 0) if isinstance(error, dict) else 0
+                )
+                if error_code == 429 or error_code >= 500:
+                    raise RetryableError(
+                        f"Telegram API {method}: retryable error {error_code}"
+                    )
+                logger.warning(f"Telegram API {method} failed: {response.get('error')}")
+                return None
+        else:
+            raise RetryableError(
+                f"Telegram API {method} subprocess failed: {result.error}"
+            )
+    except RetryableError:
+        raise
+    except Exception as e:
+        logger.error(f"Error calling Telegram API {method}: {e}")
+        return None
+
+
+def send_message_sync(
+    chat_id: int,
+    text: str,
+    parse_mode: str = "HTML",
+    reply_to: int = None,
+    reply_markup: dict = None,
+) -> Optional[dict]:
+    """
+    Send a message using the Telegram HTTP API via subprocess.
+
+    Bypasses async blocking issues.
+    """
+    payload = {"chat_id": chat_id, "text": text, "parse_mode": parse_mode}
+    if reply_to:
+        payload["reply_to_message_id"] = reply_to
+    if reply_markup:
+        payload["reply_markup"] = reply_markup
+    return _run_telegram_api_sync("sendMessage", payload)
+
+
+def edit_message_sync(
+    chat_id: int,
+    message_id: int,
+    text: str,
+    parse_mode: str = "HTML",
+    reply_markup: dict = None,
+) -> Optional[dict]:
+    """
+    Edit a message using the Telegram HTTP API via subprocess.
+
+    Bypasses async blocking issues.
+    """
+    payload = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "text": text,
+        "parse_mode": parse_mode,
+    }
+    if reply_markup:
+        payload["reply_markup"] = reply_markup
+    return _run_telegram_api_sync("editMessageText", payload)
+
+
+def send_photo_sync(
+    chat_id: int,
+    photo_path: str,
+    caption: str = None,
+    parse_mode: str = "HTML",
+) -> Optional[dict]:
+    """
+    Send a photo using the Telegram HTTP API via subprocess.
+
+    Bypasses async blocking issues.
+    """
+    bot_token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not bot_token:
+        logger.error("TELEGRAM_BOT_TOKEN not set")
+        return None
+
+    # Validate photo_path against allowed directories
+    from src.services.media_validator import validate_outbound_path
+
+    if not validate_outbound_path(Path(photo_path)):
+        logger.error(f"Photo path rejected by outbound validation: {photo_path}")
+        return None
+
+    # Use curl with multipart/form-data
+    cmd = [
+        "curl",
+        "-s",
+        "-X",
+        "POST",
+        f"https://api.telegram.org/bot{bot_token}/sendPhoto",
+        "-F",
+        f"chat_id={chat_id}",
+        "-F",
+        f"photo=@{photo_path}",
+    ]
+
+    if caption:
+        cmd.extend(["--form-string", f"caption={caption}"])
+    if parse_mode:
+        cmd.extend(["--form-string", f"parse_mode={parse_mode}"])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode == 0:
+            return json.loads(result.stdout)
+        else:
+            logger.error(f"Telegram API sendPhoto failed: {result.stderr}")
+            return None
+    except Exception as e:
+        logger.error(f"Error sending photo via Telegram API: {e}")
+        return None

--- a/tests/test_bot/test_handlers/test_base.py
+++ b/tests/test_bot/test_handlers/test_base.py
@@ -80,7 +80,7 @@ class TestClaudeModeCache:
 class TestTelegramApiSync:
     """Tests for synchronous Telegram API calls."""
 
-    @patch("src.bot.handlers.base.run_python_script")
+    @patch("src.utils.telegram_api.run_python_script")
     @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "test_token"})
     def test_run_telegram_api_sync_success(self, mock_run):
         """Successful API call returns parsed JSON."""
@@ -96,7 +96,7 @@ class TestTelegramApiSync:
         assert result is not None
         assert result.get("message_id") == 123
 
-    @patch("src.bot.handlers.base.run_python_script")
+    @patch("src.utils.telegram_api.run_python_script")
     @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "test_token"})
     def test_run_telegram_api_sync_failure(self, mock_run):
         """Failed subprocess raises RetryableError after exhausting retries."""
@@ -111,7 +111,7 @@ class TestTelegramApiSync:
         with pytest.raises(RetryableError):
             _run_telegram_api_sync("sendMessage", {"chat_id": 1, "text": "hi"})
 
-    @patch("src.bot.handlers.base.run_python_script")
+    @patch("src.utils.telegram_api.run_python_script")
     @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "test_token"})
     def test_run_telegram_api_sync_invalid_json(self, mock_run):
         """Invalid JSON response returns None."""
@@ -125,7 +125,7 @@ class TestTelegramApiSync:
         result = _run_telegram_api_sync("sendMessage", {"chat_id": 1, "text": "hi"})
         assert result is None
 
-    @patch("src.bot.handlers.base.run_python_script")
+    @patch("src.utils.telegram_api.run_python_script")
     @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "test_token"})
     def test_run_telegram_api_sync_exception(self, mock_run):
         """Exception during API call returns None."""
@@ -158,7 +158,7 @@ class TestTelegramApiSync:
 class TestSendMessageSync:
     """Tests for send_message_sync function."""
 
-    @patch("src.bot.handlers.base._run_telegram_api_sync")
+    @patch("src.utils.telegram_api._run_telegram_api_sync")
     def test_basic_message(self, mock_api):
         """Basic message call with required parameters."""
         from src.bot.handlers.base import send_message_sync
@@ -175,7 +175,7 @@ class TestSendMessageSync:
         assert payload["text"] == "Hello"
         assert payload["parse_mode"] == "HTML"
 
-    @patch("src.bot.handlers.base._run_telegram_api_sync")
+    @patch("src.utils.telegram_api._run_telegram_api_sync")
     def test_message_with_reply(self, mock_api):
         """Message with reply_to parameter."""
         from src.bot.handlers.base import send_message_sync
@@ -187,7 +187,7 @@ class TestSendMessageSync:
         payload = mock_api.call_args[0][1]
         assert payload["reply_to_message_id"] == 999
 
-    @patch("src.bot.handlers.base._run_telegram_api_sync")
+    @patch("src.utils.telegram_api._run_telegram_api_sync")
     def test_message_with_markup(self, mock_api):
         """Message with reply_markup parameter."""
         from src.bot.handlers.base import send_message_sync
@@ -204,7 +204,7 @@ class TestSendMessageSync:
 class TestEditMessageSync:
     """Tests for edit_message_sync function."""
 
-    @patch("src.bot.handlers.base._run_telegram_api_sync")
+    @patch("src.utils.telegram_api._run_telegram_api_sync")
     def test_edit_message(self, mock_api):
         """Edit message with required parameters."""
         from src.bot.handlers.base import edit_message_sync
@@ -220,7 +220,7 @@ class TestEditMessageSync:
         assert payload["message_id"] == 999
         assert payload["text"] == "Updated text"
 
-    @patch("src.bot.handlers.base._run_telegram_api_sync")
+    @patch("src.utils.telegram_api._run_telegram_api_sync")
     def test_edit_with_markup(self, mock_api):
         """Edit message with new keyboard."""
         from src.bot.handlers.base import edit_message_sync

--- a/tests/test_utils/test_retry.py
+++ b/tests/test_utils/test_retry.py
@@ -404,11 +404,11 @@ class TestTelegramSendRetry:
                 )
 
         with patch(
-            "src.bot.handlers.base.run_python_script",
+            "src.utils.telegram_api.run_python_script",
             side_effect=mock_run_python_script,
         ):
             with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "test-token"}):
-                from src.bot.handlers.base import _run_telegram_api_sync
+                from src.utils.telegram_api import _run_telegram_api_sync
 
                 result = _run_telegram_api_sync(
                     "sendMessage", {"chat_id": 1, "text": "hi"}


### PR DESCRIPTION
## Summary
- Moved `_run_telegram_api_sync`, `send_message_sync`, `edit_message_sync`, `send_photo_sync` from `src/bot/handlers/base.py` to new `src/utils/telegram_api.py`
- Updated 3 service-layer imports (`poll_scheduler`, `heartbeat_service`, `life_weeks_scheduler`) to import from `utils.telegram_api` directly — fixing upward dependency violations
- `base.py` re-exports all functions for backward compatibility with handler-layer code
- Updated test patch targets to match new module location

Closes #151

## Test plan
- [x] All 3271 tests pass
- [x] Existing imports from `bot.handlers.base` still work via re-exports
- [x] Service-layer files no longer depend on handler layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)