### PR TITLE
fix(security): P0+P1 session hijack, env var leak, path disclosure

### DIFF
--- a/src/core/config_validator.py
+++ b/src/core/config_validator.py
@@ -80,6 +80,14 @@ def validate_config(settings: Settings) -> List[str]:
                 "Set OWNER_USER_ID for multi-user deployments."
             )
 
+    # -- ALLOWED_USER_IDS warning -------------------------------------------
+    allowed = getattr(settings, "allowed_user_ids", "")
+    if not allowed or not allowed.strip():
+        logger.warning(
+            "ALLOWED_USER_IDS is empty — any Telegram user can interact with the bot "
+            "at USER tier. Set ALLOWED_USER_IDS to restrict access."
+        )
+
     return errors
 
 

--- a/src/services/claude_code_service.py
+++ b/src/services/claude_code_service.py
@@ -383,7 +383,7 @@ VAULT SEMANTIC SEARCH (supplemental to Grep/Glob):
 Use for discovering related notes, building See Also sections, or exploratory searches.
 NOT a replacement for exact text search (use Grep) or file lookup (use Glob).
 
-Commands (require: source /Volumes/LaCie/DataLake/.venv/bin/activate):
+Commands:
 - Search: python3 ~/Research/vault/scripts/vault_search.py "query" [--format see-also|wikilinks]
 - Embed new note: python3 ~/Research/vault/scripts/embed_note.py "/path/to/note.md"
 
@@ -727,9 +727,12 @@ WORKFLOW for creating notes:
             for s in result.scalars().all():
                 s.is_active = False
 
-            # Activate the target session
+            # Activate the target session (must belong to this chat)
             result = await session.execute(
-                select(ClaudeSession).where(ClaudeSession.session_id == session_id)
+                select(ClaudeSession).where(
+                    ClaudeSession.session_id == session_id,
+                    ClaudeSession.chat_id == chat_id,
+                )
             )
             db_session = result.scalar_one_or_none()
             if db_session:


### PR DESCRIPTION
## Summary
- **P0 #178**: `reactivate_session()` now validates `chat_id` ownership — prevents cross-chat session hijacking via known session ID prefix
- **P0 #176**: Config validator warns when `ALLOWED_USER_IDS` is empty (open access at USER tier). OWNER_USER_ID production enforcement already existed.
- **P1 #179**: Subprocess env scrubs all sensitive vars (`*_SECRET`, `*_TOKEN`, `*_KEY`, `*_PASSWORD` patterns + explicit blocklist). Removed `/tmp` and `/private/tmp` from `allowed_bases`.
- **P1 #180**: Removed `/Volumes/LaCie/DataLake` infrastructure path from Claude system prompt

## Test plan
- [x] 3275 tests pass (5 new security tests added)
- [x] `_scrub_env` tests: known secrets removed, suffix patterns removed, safe vars preserved
- [x] `/tmp` rejection tests updated
- [x] Cross-chat session ownership test added
- [ ] Manual: verify Claude Code still works after env scrubbing

Closes #176, closes #178, closes #179, closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)