### PR TITLE
fix(security): P1+P2 API key separation, per-user rate limiting, buffer cap, MIME validation

### DIFF
--- a/src/bot/message_handlers.py
+++ b/src/bot/message_handlers.py
@@ -68,15 +68,20 @@ async def handle_image_message(
         photo = message.photo[-1]
         file_id = photo.file_id
         logger.info(f"Photo received: {file_id}, size: {photo.width}x{photo.height}")
-    elif (
-        message.document
-        and message.document.mime_type
-        and message.document.mime_type.startswith("image/")
-    ):
-        # Handle image documents
+    elif message.document and message.document.mime_type:
+        mime = message.document.mime_type
+        # Validate MIME type against allowed image types
+        allowed = {"image/jpeg", "image/png", "image/webp", "image/gif"}
+        if mime not in allowed:
+            logger.warning("Rejected document with MIME %s (not in allowed set)", mime)
+            await message.reply_text(
+                "❌ Unsupported image format. " "Please send JPEG, PNG, WebP, or GIF."
+            )
+            return
         file_id = message.document.file_id
         logger.info(
-            f"Image document received: {file_id}, size: {message.document.file_size}"
+            f"Image document received: {file_id}, "
+            f"mime={mime}, size: {message.document.file_size}"
         )
 
     if not file_id:

--- a/tests/test_api/test_admin_auth.py
+++ b/tests/test_api/test_admin_auth.py
@@ -1,6 +1,7 @@
 """Tests for admin endpoint authentication."""
 
 import hashlib
+import hmac
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,7 +15,7 @@ os.environ["TELEGRAM_BOT_TOKEN"] = "test:bot_token"
 def get_test_admin_api_key() -> str:
     """Generate the expected admin API key for tests."""
     secret = os.environ["TELEGRAM_WEBHOOK_SECRET"]
-    return hashlib.sha256(f"{secret}:admin_api".encode()).hexdigest()
+    return hmac.new(secret.encode(), b"admin_api", hashlib.sha256).hexdigest()
 
 
 class TestWebhookAdminAuth:

--- a/tests/test_bot/test_message_handlers.py
+++ b/tests/test_bot/test_message_handlers.py
@@ -653,7 +653,7 @@ class TestHandleImageMessage:
 
     @pytest.mark.asyncio
     async def test_rejects_non_image_document(self, mock_update, mock_context):
-        """Test rejection of non-image documents."""
+        """Test rejection of non-image documents (MIME validation)."""
         from src.bot.message_handlers import handle_image_message
 
         doc = MagicMock()
@@ -667,7 +667,7 @@ class TestHandleImageMessage:
 
         mock_update.message.reply_text.assert_called_once()
         call_args = mock_update.message.reply_text.call_args[0][0]
-        assert "No image found" in call_args
+        assert "Unsupported image format" in call_args
 
     @pytest.mark.asyncio
     async def test_rejects_oversized_document(

--- a/tests/test_services/test_message_buffer.py
+++ b/tests/test_services/test_message_buffer.py
@@ -408,7 +408,7 @@ class TestMessageBufferServiceInit:
         service = MessageBufferService()
 
         assert service.buffer_timeout == 2.5
-        assert service.max_messages == 10
+        assert service.max_messages == 20
         assert service.max_wait == 30.0
         assert service._buffers == {}
         assert service._process_callback is None


### PR DESCRIPTION
## Summary
- **P1 #184**: Support `ADMIN_API_KEY` env var for explicit admin key; backward-compatible HMAC-SHA256 derivation from webhook secret
- **P2 #181**: Per-user (Telegram user_id) token-bucket rate limiting (30 msg/min) at webhook endpoint, complementing per-IP middleware
- **P2 #182**: Buffer capacity enforcement — messages beyond `max_messages` (20) dropped with warning log
- **P2 #183**: Explicit MIME type validation for document uploads (only image/jpeg, png, webp, gif accepted)

## Test plan
- [x] 3275 tests pass
- [x] Admin auth test updated for HMAC-SHA256 derivation
- [x] Non-image document test updated for MIME validation message
- [x] Buffer init test updated for new default (20)

Closes #181, closes #182, closes #183, closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)