### PR TITLE
fix(security): harden API key derivation with separate secrets (#184)

### DIFF
--- a/src/api/metrics.py
+++ b/src/api/metrics.py
@@ -136,9 +136,9 @@ async def _verify_metrics_key(
     ),
 ) -> bool:
     """Verify the admin API key for metrics access."""
-    import hashlib
     import hmac
-    import os
+
+    from ..core.security import derive_api_key
 
     if not x_api_key:
         raise HTTPException(
@@ -146,14 +146,14 @@ async def _verify_metrics_key(
             detail="Missing API key",
         )
 
-    secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "")
-    if not secret:
+    try:
+        expected = derive_api_key("admin_api")
+    except ValueError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Auth not configured",
         )
 
-    expected = hashlib.sha256(f"{secret}:admin_api".encode()).hexdigest()
     if not hmac.compare_digest(x_api_key, expected):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -150,6 +150,11 @@ class Settings(BaseSettings):
     groq_api_key: Optional[str] = None
     anthropic_api_key: Optional[str] = None
 
+    # Dedicated secret for API key derivation (HMAC-SHA256).
+    # When set, API keys are derived from this secret instead of
+    # TELEGRAM_WEBHOOK_SECRET.  Strongly recommended for production.
+    api_secret_key: Optional[str] = None
+
     # STT (Speech-to-Text) provider chain
     # Comma-separated list, tried in order. Options: groq, local_whisper
     stt_providers: str = "groq,local_whisper"

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -1,0 +1,125 @@
+"""
+Centralized API key derivation for the Telegram Agent.
+
+Supports two modes:
+1. **Dedicated secret** (recommended): When API_SECRET_KEY is set, keys are
+   derived via HMAC-SHA256 using that secret as the HMAC key and a
+   purpose-specific label as the message.
+2. **Legacy fallback**: When API_SECRET_KEY is *not* set, keys are derived
+   from TELEGRAM_WEBHOOK_SECRET using the old salted-SHA256 scheme. A
+   deprecation warning is emitted on each derivation.
+
+All callers should use ``derive_api_key(purpose)`` instead of rolling their
+own hash.  The *purpose* string (e.g. ``"admin_api"``, ``"messaging_api"``)
+ensures that each endpoint gets a distinct key even though they share the
+same root secret.
+"""
+
+import hashlib
+import hmac
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Flag to ensure the deprecation warning is logged only once per process.
+_legacy_warning_emitted = False
+
+
+def _get_api_secret_key() -> Optional[str]:
+    """Return the dedicated API secret if configured, else None.
+
+    Checks the environment variable first (matches production behavior
+    where load_dotenv may update os.environ), then falls back to the
+    Settings object (useful when env var is unset but .env has it).
+    """
+    env_val = os.getenv("API_SECRET_KEY")
+    if env_val:
+        return env_val
+
+    try:
+        from .config import get_settings
+
+        settings = get_settings()
+        val = getattr(settings, "api_secret_key", None)
+        if val:
+            return val
+    except Exception:
+        pass
+
+    return None
+
+
+def _get_webhook_secret() -> Optional[str]:
+    """Return the webhook secret (legacy source for key derivation).
+
+    Checks the environment variable first (matches the original
+    get_admin_api_key behavior where env has final say), then falls
+    back to the Settings object.
+    """
+    env_val = os.getenv("TELEGRAM_WEBHOOK_SECRET")
+    if env_val:
+        return env_val
+
+    try:
+        from .config import get_settings
+
+        settings = get_settings()
+        val = getattr(settings, "telegram_webhook_secret", None)
+        if val:
+            return val
+    except Exception:
+        pass
+
+    return None
+
+
+def derive_api_key(purpose: str) -> str:
+    """Derive a hex API key for the given *purpose* label.
+
+    Args:
+        purpose: A short identifier such as ``"admin_api"`` or
+            ``"messaging_api"``.  Must be non-empty.
+
+    Returns:
+        A 64-character lowercase hex string (256 bits).
+
+    Raises:
+        ValueError: If neither API_SECRET_KEY nor TELEGRAM_WEBHOOK_SECRET
+            is configured.
+    """
+    if not purpose:
+        raise ValueError("purpose must be a non-empty string")
+
+    # ---- preferred path: dedicated secret + HMAC-SHA256 ----
+    api_secret = _get_api_secret_key()
+    if api_secret:
+        return hmac.new(
+            api_secret.encode(),
+            purpose.encode(),
+            hashlib.sha256,
+        ).hexdigest()
+
+    # ---- legacy fallback: webhook secret + plain SHA-256 ----
+    webhook_secret = _get_webhook_secret()
+    if not webhook_secret:
+        raise ValueError(
+            "Neither API_SECRET_KEY nor TELEGRAM_WEBHOOK_SECRET is configured"
+        )
+
+    global _legacy_warning_emitted
+    if not _legacy_warning_emitted:
+        logger.warning(
+            "API_SECRET_KEY is not set — falling back to TELEGRAM_WEBHOOK_SECRET "
+            "for API key derivation. Set API_SECRET_KEY for stronger isolation."
+        )
+        _legacy_warning_emitted = True
+
+    return hashlib.sha256(f"{webhook_secret}:{purpose}".encode()).hexdigest()
+
+
+def reset_legacy_warning() -> None:
+    """Reset the one-shot deprecation flag (for tests only)."""
+    global _legacy_warning_emitted
+    _legacy_warning_emitted = False

--- a/tests/test_api/test_messaging.py
+++ b/tests/test_api/test_messaging.py
@@ -44,9 +44,10 @@ class TestMessagingApiKeyGeneration:
         """Verify messaging API key is derived from webhook secret using salted hash."""
         from src.api.messaging import get_messaging_api_key
 
-        with patch("src.api.messaging.get_settings") as mock_settings:
-            mock_settings.return_value.telegram_webhook_secret = "test_secret"
-
+        with patch.dict(
+            os.environ, {"TELEGRAM_WEBHOOK_SECRET": "test_secret"}, clear=False
+        ):
+            os.environ.pop("API_SECRET_KEY", None)
             key = get_messaging_api_key()
 
             expected = hashlib.sha256("test_secret:messaging_api".encode()).hexdigest()
@@ -57,20 +58,30 @@ class TestMessagingApiKeyGeneration:
         """Verify ValueError when webhook secret is not configured."""
         from src.api.messaging import get_messaging_api_key
 
-        with patch("src.api.messaging.get_settings") as mock_settings:
+        with (
+            patch("src.core.config.get_settings") as mock_settings,
+            patch.dict(os.environ, {}, clear=False),
+        ):
             mock_settings.return_value.telegram_webhook_secret = ""
+            mock_settings.return_value.api_secret_key = None
+            os.environ.pop("TELEGRAM_WEBHOOK_SECRET", None)
+            os.environ.pop("API_SECRET_KEY", None)
 
-            with pytest.raises(
-                ValueError, match="TELEGRAM_WEBHOOK_SECRET not configured"
-            ):
+            with pytest.raises(ValueError):
                 get_messaging_api_key()
 
     def test_get_messaging_api_key_raises_when_secret_is_none(self):
         """Verify ValueError when webhook secret is None."""
         from src.api.messaging import get_messaging_api_key
 
-        with patch("src.api.messaging.get_settings") as mock_settings:
+        with (
+            patch("src.core.config.get_settings") as mock_settings,
+            patch.dict(os.environ, {}, clear=False),
+        ):
             mock_settings.return_value.telegram_webhook_secret = None
+            mock_settings.return_value.api_secret_key = None
+            os.environ.pop("TELEGRAM_WEBHOOK_SECRET", None)
+            os.environ.pop("API_SECRET_KEY", None)
 
             with pytest.raises(ValueError):
                 get_messaging_api_key()
@@ -79,9 +90,10 @@ class TestMessagingApiKeyGeneration:
         """Verify messaging API key uses different salt than admin API key."""
         from src.api.messaging import get_messaging_api_key
 
-        with patch("src.api.messaging.get_settings") as mock_settings:
-            mock_settings.return_value.telegram_webhook_secret = "test_secret"
-
+        with patch.dict(
+            os.environ, {"TELEGRAM_WEBHOOK_SECRET": "test_secret"}, clear=False
+        ):
+            os.environ.pop("API_SECRET_KEY", None)
             messaging_key = get_messaging_api_key()
             # Admin key would use ":admin_api" salt
             admin_key = hashlib.sha256("test_secret:admin_api".encode()).hexdigest()

--- a/tests/test_core/test_security.py
+++ b/tests/test_core/test_security.py
@@ -1,0 +1,222 @@
+"""Tests for centralized API key derivation (src/core/security.py).
+
+Covers:
+- HMAC-SHA256 derivation with dedicated API_SECRET_KEY
+- Legacy fallback to TELEGRAM_WEBHOOK_SECRET with deprecation warning
+- ValueError when neither secret is configured
+- Key isolation: different purposes produce different keys
+"""
+
+import hashlib
+import hmac
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+# Ensure minimal env for test imports
+os.environ.setdefault("TELEGRAM_WEBHOOK_SECRET", "test_webhook_secret_12345")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test:bot_token")
+
+
+class TestDeriveApiKeyWithDedicatedSecret:
+    """Tests for the preferred HMAC-SHA256 path (API_SECRET_KEY set)."""
+
+    def setup_method(self):
+        from src.core.security import reset_legacy_warning
+
+        reset_legacy_warning()
+
+    def test_hmac_sha256_derivation(self):
+        """derive_api_key uses HMAC-SHA256 when API_SECRET_KEY is set."""
+        from src.core.security import derive_api_key
+
+        secret = "my_dedicated_secret"
+        with patch.dict(os.environ, {"API_SECRET_KEY": secret}):
+            key = derive_api_key("admin_api")
+
+        expected = hmac.new(secret.encode(), b"admin_api", hashlib.sha256).hexdigest()
+        assert key == expected
+        assert len(key) == 64  # SHA-256 hex digest length
+
+    def test_different_purposes_produce_different_keys(self):
+        """Different purpose labels produce distinct keys."""
+        from src.core.security import derive_api_key
+
+        secret = "my_dedicated_secret"
+        with patch.dict(os.environ, {"API_SECRET_KEY": secret}):
+            admin_key = derive_api_key("admin_api")
+            messaging_key = derive_api_key("messaging_api")
+
+        assert admin_key != messaging_key
+
+    def test_no_deprecation_warning_with_dedicated_secret(self, caplog):
+        """No deprecation warning when API_SECRET_KEY is set."""
+        from src.core.security import derive_api_key
+
+        with patch.dict(os.environ, {"API_SECRET_KEY": "some_secret"}):
+            with caplog.at_level(logging.WARNING, logger="src.core.security"):
+                derive_api_key("admin_api")
+
+        assert "falling back" not in caplog.text.lower()
+
+    def test_dedicated_secret_differs_from_legacy_output(self):
+        """HMAC path produces a different key than legacy SHA-256 path."""
+        from src.core.security import derive_api_key
+
+        webhook_secret = "shared_secret"
+        api_secret = "shared_secret"  # same value, different algorithm
+
+        # Legacy output
+        legacy_key = hashlib.sha256(f"{webhook_secret}:admin_api".encode()).hexdigest()
+
+        # HMAC output
+        with patch.dict(
+            os.environ,
+            {"API_SECRET_KEY": api_secret, "TELEGRAM_WEBHOOK_SECRET": webhook_secret},
+        ):
+            hmac_key = derive_api_key("admin_api")
+
+        assert hmac_key != legacy_key
+
+
+class TestDeriveApiKeyLegacyFallback:
+    """Tests for the legacy fallback path (no API_SECRET_KEY)."""
+
+    def setup_method(self):
+        from src.core.security import reset_legacy_warning
+
+        reset_legacy_warning()
+
+    def test_legacy_sha256_derivation(self):
+        """Falls back to salted SHA-256 when API_SECRET_KEY is absent."""
+        from src.core.security import derive_api_key
+
+        webhook_secret = "test_webhook_secret_12345"
+        with patch.dict(
+            os.environ, {"TELEGRAM_WEBHOOK_SECRET": webhook_secret}, clear=False
+        ):
+            os.environ.pop("API_SECRET_KEY", None)
+            key = derive_api_key("admin_api")
+
+        expected = hashlib.sha256(f"{webhook_secret}:admin_api".encode()).hexdigest()
+        assert key == expected
+        assert len(key) == 64
+
+    def test_backward_compat_admin_key(self):
+        """Legacy admin key matches the old derivation exactly."""
+        from src.core.security import derive_api_key
+
+        secret = "test_secret"
+        old_key = hashlib.sha256(f"{secret}:admin_api".encode()).hexdigest()
+
+        with patch.dict(os.environ, {"TELEGRAM_WEBHOOK_SECRET": secret}, clear=False):
+            os.environ.pop("API_SECRET_KEY", None)
+            new_key = derive_api_key("admin_api")
+
+        assert new_key == old_key
+
+    def test_backward_compat_messaging_key(self):
+        """Legacy messaging key matches the old derivation exactly."""
+        from src.core.security import derive_api_key
+
+        secret = "test_secret"
+        old_key = hashlib.sha256(f"{secret}:messaging_api".encode()).hexdigest()
+
+        with patch.dict(os.environ, {"TELEGRAM_WEBHOOK_SECRET": secret}, clear=False):
+            os.environ.pop("API_SECRET_KEY", None)
+            new_key = derive_api_key("messaging_api")
+
+        assert new_key == old_key
+
+    def test_deprecation_warning_logged_on_fallback(self, caplog):
+        """A deprecation warning is logged once when using the legacy path."""
+        from src.core.security import derive_api_key
+
+        with patch.dict(
+            os.environ, {"TELEGRAM_WEBHOOK_SECRET": "test_secret"}, clear=False
+        ):
+            os.environ.pop("API_SECRET_KEY", None)
+            with caplog.at_level(logging.WARNING, logger="src.core.security"):
+                derive_api_key("admin_api")
+
+        assert "API_SECRET_KEY is not set" in caplog.text
+        assert "falling back" in caplog.text.lower()
+
+    def test_deprecation_warning_logged_only_once(self, caplog):
+        """The fallback warning fires only once, not on every call."""
+        from src.core.security import derive_api_key, reset_legacy_warning
+
+        reset_legacy_warning()
+
+        with patch.dict(
+            os.environ, {"TELEGRAM_WEBHOOK_SECRET": "test_secret"}, clear=False
+        ):
+            os.environ.pop("API_SECRET_KEY", None)
+            with caplog.at_level(logging.WARNING, logger="src.core.security"):
+                derive_api_key("admin_api")
+                derive_api_key("messaging_api")
+
+        # Should appear exactly once
+        count = caplog.text.count("API_SECRET_KEY is not set")
+        assert count == 1
+
+
+class TestDeriveApiKeyNoSecret:
+    """Tests for the error case when no secret is configured at all."""
+
+    def setup_method(self):
+        from src.core.security import reset_legacy_warning
+
+        reset_legacy_warning()
+
+    def test_raises_when_no_secrets_configured(self):
+        """ValueError raised when neither secret is available."""
+        from src.core.security import derive_api_key
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("API_SECRET_KEY", None)
+            os.environ.pop("TELEGRAM_WEBHOOK_SECRET", None)
+            # Patch get_settings to return empty secrets (fallback path)
+            with patch("src.core.config.get_settings") as mock_settings:
+                mock_settings.return_value.api_secret_key = None
+                mock_settings.return_value.telegram_webhook_secret = None
+                with pytest.raises(ValueError):
+                    derive_api_key("admin_api")
+
+    def test_raises_with_empty_purpose(self):
+        """ValueError raised for empty purpose string."""
+        from src.core.security import derive_api_key
+
+        with pytest.raises(ValueError, match="purpose must be a non-empty"):
+            derive_api_key("")
+
+
+class TestResetLegacyWarning:
+    """Tests for the test helper reset_legacy_warning()."""
+
+    def test_reset_allows_warning_again(self, caplog):
+        """After reset, the deprecation warning fires again."""
+        from src.core.security import derive_api_key, reset_legacy_warning
+
+        reset_legacy_warning()
+        with patch.dict(
+            os.environ, {"TELEGRAM_WEBHOOK_SECRET": "test_secret"}, clear=False
+        ):
+            os.environ.pop("API_SECRET_KEY", None)
+            with caplog.at_level(logging.WARNING, logger="src.core.security"):
+                derive_api_key("admin_api")
+            first_count = caplog.text.count("API_SECRET_KEY is not set")
+
+        reset_legacy_warning()
+        with patch.dict(
+            os.environ, {"TELEGRAM_WEBHOOK_SECRET": "test_secret"}, clear=False
+        ):
+            os.environ.pop("API_SECRET_KEY", None)
+            with caplog.at_level(logging.WARNING, logger="src.core.security"):
+                derive_api_key("admin_api")
+            second_count = caplog.text.count("API_SECRET_KEY is not set")
+
+        assert first_count == 1
+        assert second_count == 2  # One more after reset


### PR DESCRIPTION
## Summary
- Centralized API key derivation in `src/core/security.py` with HMAC-SHA256 when `API_SECRET_KEY` env var is set
- Legacy SHA-256 fallback with deprecation warning for backward compatibility
- All API endpoints (`webhook.py`, `messaging.py`, `metrics.py`) delegate to the new module

## Test plan
- [x] 12 new tests covering HMAC path, legacy fallback, deprecation warning, error cases
- [x] All 3471 tests pass

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)