### PR TITLE
fix(security): add message buffer size limit (#182)

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -76,6 +76,7 @@ timeouts:
 limits:
   # Message buffering
   max_buffer_messages: 10            # Max messages before forced flush
+  max_buffer_size: 20                # Hard cap on buffer size per user; excess messages dropped
 
   # LRU caches
   claude_mode_cache_size: 10000      # Cache for claude mode state

--- a/config/profiles/testing.yaml
+++ b/config/profiles/testing.yaml
@@ -28,6 +28,7 @@ timeouts:
 # Reduced limits for test performance
 limits:
   max_buffer_messages: 3
+  max_buffer_size: 5
   claude_mode_cache_size: 10
   admin_cache_size: 10
   reply_context_cache_size: 10

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -143,6 +143,7 @@ class Settings(BaseSettings):
 
     # Limits
     max_buffer_messages: int = 10
+    max_buffer_size: int = 20
     max_buffer_wait: float = 30.0
 
     # API Keys (optional, loaded from env)

--- a/src/core/services.py
+++ b/src/core/services.py
@@ -148,6 +148,7 @@ def setup_services() -> None:
             buffer_timeout=settings.buffer_timeout,
             max_messages=settings.max_buffer_messages,
             max_wait=settings.max_buffer_wait,
+            max_buffer_size=settings.max_buffer_size,
         )
 
     container.register("message_buffer", create_buffer_service)


### PR DESCRIPTION
## Summary
- Enforces configurable `max_buffer_size` (default 20) per user per buffer window
- Excess messages dropped silently with WARNING logged on first overflow per window
- Config wired through `defaults.yaml`, `Settings`, and service container

## Test plan
- [x] 9 new tests covering limit enforcement, overflow logging, flush reset, config passthrough
- [x] All 3468 tests pass

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)