### PR TITLE
feat(i18n): extract service-layer strings to locale files

### DIFF
--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -218,6 +218,19 @@ commands:
 
   gallery:
     error: "Sorry, there was an error loading your gallery. Please try again later."
+    title: "Your Image Gallery"
+    empty_hint: "No images found yet!\n\nSend me some images to get started with analysis!"
+    total_images: "Total Images: {count}"
+    image_label: "Image {n}"
+    details_title: "Image Details"
+    mode_label: "Mode:"
+    date_label: "Date:"
+    size_label: "Size:"
+    processed_label: "Processed in: {time}s"
+    similar_label: "Similar Images: {count} found"
+    analysis_label: "Analysis:"
+    no_description: "No description available"
+    parsing_error: "Analysis parsing error"
 
   language:
     title: "Language Settings"
@@ -351,6 +364,8 @@ keyboard:
   cmd_deletedata: "Delete your data"
 
 accountability:
+  checkin_reminder_title: "Check-in Reminder"
+  checkin_not_checked: "You haven't checked in yet for:"
   streak_days:
     one: "{n} day"
     other: "{n} days"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -217,6 +217,19 @@ commands:
 
   gallery:
     error: "Ошибка загрузки галереи. Попробуйте позже."
+    title: "Ваша галерея"
+    empty_hint: "Изображений пока нет!\n\nОтправьте изображения для анализа!"
+    total_images: "Всего изображений: {count}"
+    image_label: "Изображение {n}"
+    details_title: "Детали изображения"
+    mode_label: "Режим:"
+    date_label: "Дата:"
+    size_label: "Размер:"
+    processed_label: "Обработано за: {time}с"
+    similar_label: "Похожие изображения: {count}"
+    analysis_label: "Анализ:"
+    no_description: "Описание отсутствует"
+    parsing_error: "Ошибка разбора анализа"
 
   language:
     title: "Настройки языка"
@@ -350,6 +363,8 @@ keyboard:
   cmd_deletedata: "Удаление данных"
 
 accountability:
+  checkin_reminder_title: "Напоминание о чек-ине"
+  checkin_not_checked: "Вы ещё не отметились по:"
   streak_days:
     one: "{n} день"
     few: "{n} дня"

--- a/src/bot/callback_handlers.py
+++ b/src/bot/callback_handlers.py
@@ -804,7 +804,7 @@ async def handle_gallery_callback(
             # Get paginated images
             images, total_images, total_pages = (
                 await gallery_service.get_user_images_paginated(
-                    user_id=user_id, page=page
+                    user_id=user_id, page=page, locale=locale
                 )
             )
 
@@ -814,6 +814,7 @@ async def handle_gallery_callback(
                 page=page,
                 total_pages=total_pages,
                 total_images=total_images,
+                locale=locale,
             )
 
             # Create navigation keyboard
@@ -838,14 +839,18 @@ async def handle_gallery_callback(
                 return
 
             # Get image details
-            image_data = await gallery_service.get_image_by_id(image_id, user_id)
+            image_data = await gallery_service.get_image_by_id(
+                image_id, user_id, locale=locale
+            )
 
             if not image_data:
                 await query.message.reply_text("❌ Image not found or access denied.")
                 return
 
             # Format detailed response
-            response_text = gallery_service.format_image_details(image_data)
+            response_text = gallery_service.format_image_details(
+                image_data, locale=locale
+            )
 
             # Create detail keyboard with reanalysis options
             # Try to get page from query message (fallback to page 1)
@@ -877,7 +882,9 @@ async def handle_gallery_callback(
                 return
 
             # Get the image data to get file_id
-            image_data = await gallery_service.get_image_by_id(image_id, user_id)
+            image_data = await gallery_service.get_image_by_id(
+                image_id, user_id, locale=locale
+            )
             if not image_data:
                 await query.message.reply_text("❌ Image not found or access denied.")
                 return

--- a/src/bot/handlers/core_commands.py
+++ b/src/bot/handlers/core_commands.py
@@ -195,7 +195,9 @@ async def gallery_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     try:
         images, total_images, total_pages = (
-            await gallery_service.get_user_images_paginated(user_id=user.id, page=page)
+            await gallery_service.get_user_images_paginated(
+                user_id=user.id, page=page, locale=locale
+            )
         )
 
         response_text = gallery_service.format_gallery_page(
@@ -203,6 +205,7 @@ async def gallery_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             page=page,
             total_pages=total_pages,
             total_images=total_images,
+            locale=locale,
         )
 
         from ..keyboard_utils import get_keyboard_utils

--- a/src/services/accountability_scheduler.py
+++ b/src/services/accountability_scheduler.py
@@ -122,8 +122,10 @@ async def send_checkin_reminder(context) -> None:
                 return
 
             # Build reminder message
-            lines = ["⏰ <b>Check-in Reminder</b>\n"]
-            lines.append("You haven't checked in yet for:\n")
+            reminder_title = t("accountability.checkin_reminder_title", locale)
+            lines = [f"⏰ <b>{reminder_title}</b>\n"]
+            not_checked = t("accountability.checkin_not_checked", locale)
+            lines.append(f"{not_checked}\n")
 
             keyboard = []
             for tracker, streak in unchecked:


### PR DESCRIPTION
## Summary
- Extract hardcoded user-facing strings from `gallery_service.py` (14 keys) and `accountability_scheduler.py` (2 keys) into `en.yaml`/`ru.yaml` locale files
- Add `locale` parameter to all gallery service public methods (`get_user_images_paginated`, `get_image_by_id`, `format_gallery_page`, `format_image_details`)
- Update all callers in `core_commands.py` and `callback_handlers.py` to pass locale through

Closes #88

## Test plan
- [x] All 3289 existing tests pass
- [ ] Verify gallery displays correctly in English
- [ ] Verify gallery displays correctly in Russian
- [ ] Verify accountability check-in reminders use localized strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)