### PR TITLE
fix(ci): Resolve all CI failures — formatting, types, and mixin attrs

### DIFF
--- a/src/bot/processors/content.py
+++ b/src/bot/processors/content.py
@@ -13,7 +13,7 @@ import os
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from ...core.config import get_settings
 from ...core.i18n import get_user_locale
@@ -32,6 +32,14 @@ logger = logging.getLogger(__name__)
 
 class ContentProcessorMixin:
     """Mixin for video, document, contact, and poll processing."""
+
+    if TYPE_CHECKING:
+        # Provided by CombinedMessageProcessor / TextProcessorMixin / MediaProcessorMixin
+        reply_service: Any
+        _mark_as_read_sync: Any
+        _send_typing_sync: Any
+        _send_message_sync: Any
+        _handle_transcription_routing: Any
 
     async def _process_with_videos(
         self,

--- a/src/bot/processors/media.py
+++ b/src/bot/processors/media.py
@@ -14,7 +14,7 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from ...core.config import get_settings
 from ...core.i18n import get_user_locale
@@ -30,6 +30,13 @@ logger = logging.getLogger(__name__)
 
 class MediaProcessorMixin:
     """Mixin for image and voice message processing."""
+
+    if TYPE_CHECKING:
+        # Provided by CombinedMessageProcessor / TextProcessorMixin at runtime
+        reply_service: Any
+        _mark_as_read_sync: Any
+        _send_typing_sync: Any
+        _send_message_sync: Any
 
     async def _process_with_images(
         self,

--- a/src/bot/processors/router.py
+++ b/src/bot/processors/router.py
@@ -151,7 +151,7 @@ class CombinedMessageProcessor(
 
                 # Send confirmation message if configured
                 if show_confirmation:
-                    from ..handlers.formatting import send_message_sync
+                    from ...utils.telegram_api import send_message_sync
 
                     confirmation_msg = get_config_value(
                         "messages.collect_mode_on",
@@ -161,7 +161,6 @@ class CombinedMessageProcessor(
                         send_message_sync(
                             chat_id=combined.chat_id,
                             text=confirmation_msg,
-                            token=get_settings().telegram_bot_token,
                             parse_mode="HTML",
                         )
                     except Exception as e:

--- a/src/services/heartbeat_service.py
+++ b/src/services/heartbeat_service.py
@@ -273,9 +273,7 @@ class HeartbeatService:
             else:
                 status = "ok"
 
-            return CheckResult(
-                "database_size", status, f"{size_mb}MB", value=size_mb
-            )
+            return CheckResult("database_size", status, f"{size_mb}MB", value=size_mb)
         except Exception as e:
             return CheckResult("database_size", "warning", f"Check failed: {e}")
 

--- a/src/services/resource_monitor_service.py
+++ b/src/services/resource_monitor_service.py
@@ -60,9 +60,10 @@ class ResourceMonitor:
 
         alerts: List[CheckResult] = []
         for result in raw:
-            if isinstance(result, Exception):
+            if isinstance(result, BaseException):
                 logger.warning("Resource check crashed: %s", result)
                 continue
+            assert isinstance(result, CheckResult)
             if result.status in ("warning", "critical"):
                 if self._should_alert(result.name):
                     alerts.append(result)

--- a/tests/test_services/test_resource_monitor_service.py
+++ b/tests/test_services/test_resource_monitor_service.py
@@ -8,7 +8,6 @@ import pytest
 
 from src.services.resource_monitor_service import ResourceMonitor, _get_chat_ids
 
-
 # ---------------------------------------------------------------------------
 # ResourceMonitor — cooldown logic
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes all CI failures on `main` so that feature branches can pass CI.

- **Black formatting**: `heartbeat_service.py` and `test_resource_monitor_service.py` needed reformatting (introduced in the #152 refactor merge)
- **mypy (36 errors → 0)**:
  - Processor mixin classes (`media.py`, `content.py`, `text.py`, `collect.py`) referenced attributes defined in sibling mixins — added `TYPE_CHECKING` attribute stubs
  - `router.py`: fixed wrong import path (`formatting` → `telegram_api`) and removed non-existent `token=` parameter
  - `text.py`: guarded `context.user_data` against `None`; renamed `poll_opt` loop var to avoid str/PollOption type clash
  - `collect.py`: handled `timedelta|int` duration from python-telegram-bot v21+; fixed variable redefinition
  - `resource_monitor_service.py`: narrowed `asyncio.gather` return type with `isinstance` + `assert`

## Test plan

- [x] `mypy src/` — 0 errors across 178 source files
- [x] `black --check src/ tests/` — all files clean
- [x] `pytest tests/ --ignore=tests/test_api` — 3535 passed, 0 failures
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)