### PR TITLE
fix: Sanitize user-facing error messages (#209)

### DIFF
--- a/src/bot/callback_handlers.py
+++ b/src/bot/callback_handlers.py
@@ -21,6 +21,7 @@ from ..services.cache_service import get_cache_service
 from ..services.image_service import get_image_service
 from ..services.llm_service import get_llm_service
 from ..services.similarity_service import get_similarity_service
+from ..core.error_messages import sanitize_error
 from ..utils.session_emoji import format_session_id
 from .callback_data_manager import get_callback_data_manager
 from .keyboard_utils import get_keyboard_utils
@@ -1555,7 +1556,7 @@ async def handle_claude_callback(
                         bot_token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
                         send_message_sync(
                             chat_id,
-                            f"❌ Retry failed: {str(e)[:200]}",
+                            f"❌ Retry failed. {sanitize_error(e)}",
                             bot_token,
                         )
 
@@ -2021,7 +2022,9 @@ async def handle_note_callback(query, params) -> None:
 
         except Exception as e:
             logger.error(f"Error reading note {relative_path}: {e}")
-            await query.message.reply_text(f"Error reading note: {str(e)}")
+            await query.message.reply_text(
+                sanitize_error(e, context="reading note")
+            )
 
     else:
         logger.warning(f"Unknown note action: {action}")

--- a/src/bot/handlers/claude_commands.py
+++ b/src/bot/handlers/claude_commands.py
@@ -29,6 +29,7 @@ from telegram.ext import ContextTypes
 
 from ...core.authorization import AuthTier, require_tier
 from ...core.config import PROJECT_ROOT, get_settings
+from ...core.error_messages import sanitize_error
 from ...core.i18n import get_user_locale_from_update, t
 from ...utils.session_emoji import format_session_id
 from .base import (
@@ -1379,7 +1380,7 @@ async def execute_claude_prompt(
         edit_message_sync(
             chat_id=chat.id,
             message_id=status_msg_id,
-            text=f"❌ {t('claude.error_prefix', locale, error=str(e))}",
+            text=f"❌ {t('claude.error_prefix', locale, error=sanitize_error(e))}",
             parse_mode="HTML",
         )
 
@@ -1725,7 +1726,7 @@ async def forward_voice_to_claude(
         edit_message_sync(
             chat_id=chat_id,
             message_id=status_msg_id,
-            text=f"❌ {t('claude.voice_forward_error', error=str(e))}",
+            text=f"❌ {t('claude.voice_forward_error', error=sanitize_error(e))}",
             parse_mode="HTML",
         )
 

--- a/src/bot/handlers/note_commands.py
+++ b/src/bot/handlers/note_commands.py
@@ -16,6 +16,7 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from ...core.config import get_settings
+from ...core.error_messages import sanitize_error
 from ...core.i18n import get_user_locale_from_update, t
 from .formatting import markdown_to_telegram_html, split_message
 
@@ -171,7 +172,7 @@ async def view_note_command(
         logger.error(f"Error reading note {note_file}: {e}")
         if update.message:
             await update.message.reply_text(
-                "❌ " + t("note.read_error", locale, error=str(e))
+                "❌ " + t("note.read_error", locale, error=sanitize_error(e))
             )
 
 

--- a/src/bot/handlers/poll_handlers.py
+++ b/src/bot/handlers/poll_handlers.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, Optional
 from telegram import Update
 from telegram.ext import CommandHandler, ContextTypes, PollAnswerHandler
 
+from ...core.error_messages import sanitize_error
 from ...core.i18n import get_user_locale_from_update, t
 from ...services.polling_service import get_polling_service
 
@@ -167,7 +168,7 @@ async def forward_poll_to_claude(
         edit_message_sync(
             chat_id=chat_id,
             message_id=status_msg_id,
-            text="❌ " + t("polls.forward_error", locale, error=str(e)),
+            text="❌ " + t("polls.forward_error", locale, error=sanitize_error(e)),
             parse_mode="HTML",
         )
 
@@ -460,7 +461,8 @@ async def _send_poll_now(
     except Exception as e:
         logger.error(f"Error sending poll: {e}", exc_info=True)
         await update.message.reply_text(
-            "❌ " + t("polls.send_error", locale, error=str(e)), parse_mode="HTML"
+            "❌ " + t("polls.send_error", locale, error=sanitize_error(e)),
+            parse_mode="HTML",
         )
 
 
@@ -539,7 +541,8 @@ async def _show_status(
     except Exception as e:
         logger.error(f"Error showing poll status: {e}", exc_info=True)
         await update.message.reply_text(
-            "❌ " + t("polls.error", locale, error=str(e)), parse_mode="HTML"
+            "❌ " + t("polls.error", locale, error=sanitize_error(e)),
+            parse_mode="HTML",
         )
 
 
@@ -612,7 +615,8 @@ async def _show_statistics(
     except Exception as e:
         logger.error(f"Error showing statistics: {e}", exc_info=True)
         await update.message.reply_text(
-            "❌ " + t("polls.error", locale, error=str(e)), parse_mode="HTML"
+            "❌ " + t("polls.error", locale, error=sanitize_error(e)),
+            parse_mode="HTML",
         )
 
 

--- a/src/bot/handlers/srs_handlers.py
+++ b/src/bot/handlers/srs_handlers.py
@@ -8,6 +8,7 @@ import logging
 from telegram import Update
 from telegram.ext import CallbackQueryHandler, CommandHandler, ContextTypes
 
+from src.core.error_messages import sanitize_error
 from src.core.i18n import get_user_locale_from_update, t
 from src.services.srs_service import srs_service
 
@@ -83,7 +84,9 @@ async def srs_stats_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     except Exception as e:
         logger.error(f"Error showing SRS stats: {e}", exc_info=True)
-        await update.message.reply_text("❌ " + t("srs.error", locale, error=str(e)))
+        await update.message.reply_text(
+            "❌ " + t("srs.error", locale, error=sanitize_error(e))
+        )
 
 
 async def srs_callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/src/bot/processors/collect.py
+++ b/src/bot/processors/collect.py
@@ -17,6 +17,7 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
+from ...core.error_messages import sanitize_error
 from ...core.i18n import get_user_locale
 from ...services.message_buffer import BufferedMessage, CombinedMessage
 from ...services.stt_service import get_stt_service
@@ -467,7 +468,7 @@ class CollectProcessorMixin:
                 try:
                     await context.bot.send_message(
                         chat_id=combined.chat_id,
-                        text=f"Error processing collected items: {str(e)[:100]}",
+                        text=sanitize_error(e, context="processing collected items"),
                     )
                 except Exception:
                     pass

--- a/src/bot/processors/content.py
+++ b/src/bot/processors/content.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 from ...core.config import get_settings
+from ...core.error_messages import sanitize_error
 from ...core.i18n import get_user_locale
 from ...services.media_validator import validate_media
 from ...services.message_buffer import CombinedMessage
@@ -374,7 +375,7 @@ class ContentProcessorMixin:
                     try:
                         await context.bot.send_message(
                             chat_id=combined.chat_id,
-                            text=f"Error processing video: {str(e)[:100]}",
+                            text=sanitize_error(e, context="processing video"),
                         )
                     except Exception:
                         pass

--- a/src/bot/processors/media.py
+++ b/src/bot/processors/media.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 from ...core.config import get_settings
+from ...core.error_messages import sanitize_error
 from ...core.i18n import get_user_locale
 from ...services.media_validator import strip_metadata, validate_media
 from ...services.message_buffer import CombinedMessage
@@ -221,7 +222,7 @@ class MediaProcessorMixin:
                 try:
                     await context.bot.send_message(
                         chat_id=combined.chat_id,
-                        text=f"Error processing image: {str(e)[:100]}",
+                        text=sanitize_error(e, context="processing image"),
                     )
                 except Exception:
                     pass
@@ -429,7 +430,7 @@ class MediaProcessorMixin:
                     try:
                         await context.bot.send_message(
                             chat_id=combined.chat_id,
-                            text=f"Error processing voice: {str(e)[:100]}",
+                            text=sanitize_error(e, context="processing voice message"),
                         )
                     except Exception:
                         pass

--- a/src/bot/processors/router.py
+++ b/src/bot/processors/router.py
@@ -13,6 +13,7 @@ import time
 from typing import Optional
 
 from ...core.config import get_config_value
+from ...core.error_messages import sanitize_error
 from ...services.message_buffer import CombinedMessage
 from ...services.message_persistence_service import persist_message
 from ...services.reply_context import (
@@ -435,7 +436,7 @@ class CombinedMessageProcessor(
                     f"Failed to save life weeks reflection: {e}", exc_info=True
                 )
                 await combined.primary_message.reply_text(
-                    f"❌ Failed to save reflection: {str(e)}",
+                    f"❌ {sanitize_error(e, context='saving reflection')}",
                     parse_mode="HTML",
                 )
                 return

--- a/src/bot/processors/text.py
+++ b/src/bot/processors/text.py
@@ -18,6 +18,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, Optional
 
+from ...core.error_messages import sanitize_error
 from ...services.message_buffer import CombinedMessage
 from ...services.reply_context import MessageType, ReplyContext
 from ...utils.task_tracker import create_tracked_task
@@ -202,7 +203,7 @@ class TextProcessorMixin:
                 try:
                     await context.bot.send_message(
                         chat_id=combined.chat_id,
-                        text=f"Error processing /{command_type} command: {str(e)[:100]}",
+                        text=sanitize_error(e, context=f"processing /{command_type} command"),
                     )
                 except Exception:
                     pass
@@ -276,7 +277,7 @@ class TextProcessorMixin:
                 try:
                     await context.bot.send_message(
                         chat_id=combined.chat_id,
-                        text=f"Error processing Claude command: {str(e)[:100]}",
+                        text=sanitize_error(e, context="processing Claude command"),
                     )
                 except Exception:
                     pass
@@ -390,7 +391,7 @@ class TextProcessorMixin:
                     try:
                         await context.bot.send_message(
                             chat_id=combined.chat_id,
-                            text=f"Error processing message: {str(e)[:100]}",
+                            text=sanitize_error(e, context="processing message"),
                         )
                     except Exception:
                         pass
@@ -512,7 +513,7 @@ class TextProcessorMixin:
                     try:
                         await context.bot.send_message(
                             chat_id=combined.chat_id,
-                            text=f"Error processing poll: {str(e)[:100]}",
+                            text=sanitize_error(e, context="processing poll"),
                         )
                     except Exception:
                         pass

--- a/src/core/error_messages.py
+++ b/src/core/error_messages.py
@@ -1,0 +1,122 @@
+"""
+User-facing error message sanitization.
+
+Maps exception types and patterns to friendly, safe messages that
+never expose internal details (file paths, API keys, stack traces, etc.)
+to Telegram users.
+
+Usage:
+    from src.core.error_messages import sanitize_error
+
+    try:
+        ...
+    except Exception as e:
+        logger.error(f"Operation failed: {e}", exc_info=True)
+        user_msg = sanitize_error(e, context="processing your image")
+        await message.reply_text(f"Sorry, {user_msg}")
+"""
+
+import logging
+import re
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Default fallback for any unrecognised exception
+_DEFAULT_MESSAGE = "Something went wrong. Please try again later."
+
+# Maps exception types to user-friendly messages.
+# Order matters: more specific types first.
+_TYPE_MAP: dict[type, str] = {
+    ConnectionError: (
+        "Could not connect to the service. Please try again in a moment."
+    ),
+    TimeoutError: (
+        "The request took too long to complete. Please try again."
+    ),
+    PermissionError: (
+        "A permissions issue occurred. Please try again or contact support."
+    ),
+    FileNotFoundError: (
+        "A required resource could not be found. Please try again."
+    ),
+    KeyError: (
+        "A configuration issue occurred. Please try again later."
+    ),
+    ValueError: (
+        "The request could not be processed. Please try again."
+    ),
+}
+
+# Patterns matched against str(e).lower() for keyword-based detection.
+# Each tuple: (compiled regex, friendly message)
+_KEYWORD_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (
+        re.compile(r"rate.?limit", re.IGNORECASE),
+        "Too many requests. Please wait a moment and try again.",
+    ),
+    (
+        re.compile(r"auth|api.?key|credentials?|unauthorized", re.IGNORECASE),
+        "A service configuration issue occurred. Please contact support.",
+    ),
+    (
+        re.compile(r"database|sqlite|operational.?error|locked", re.IGNORECASE),
+        "A temporary data issue occurred. Please try again in a moment.",
+    ),
+    (
+        re.compile(r"timeout|timed?\s*out", re.IGNORECASE),
+        "The request took too long to complete. Please try again.",
+    ),
+    (
+        re.compile(r"connect|refused|unreachable", re.IGNORECASE),
+        "Could not connect to the service. Please try again in a moment.",
+    ),
+]
+
+
+def sanitize_error(
+    exc: Optional[BaseException],
+    *,
+    context: Optional[str] = None,
+) -> str:
+    """Return a user-safe error message for *exc*.
+
+    The returned string never contains raw exception text, file paths,
+    API keys, or other internal details.
+
+    Args:
+        exc: The caught exception (or None).
+        context: Optional human-readable description of the operation
+            that failed (e.g. ``"processing your image"``).  When
+            provided, the message will read
+            ``"Sorry, there was an error <context>. <reason>"``
+
+    Returns:
+        A sanitized, user-friendly error description.
+    """
+    if exc is None:
+        message = _DEFAULT_MESSAGE
+    else:
+        message = _resolve_message(exc)
+
+    if context:
+        return f"Sorry, there was an error {context}. {message}"
+
+    return message
+
+
+def _resolve_message(exc: BaseException) -> str:
+    """Pick the best user-facing message for *exc*."""
+    # 1. Check the type hierarchy (supports subclasses via isinstance)
+    for exc_type, msg in _TYPE_MAP.items():
+        if isinstance(exc, exc_type):
+            return msg
+
+    # 2. Check keyword patterns in the stringified exception
+    raw = str(exc)
+    for pattern, msg in _KEYWORD_PATTERNS:
+        if pattern.search(raw):
+            return msg
+
+    # 3. Fallback
+    return _DEFAULT_MESSAGE

--- a/tests/test_bot/test_callback_error_sanitization.py
+++ b/tests/test_bot/test_callback_error_sanitization.py
@@ -1,0 +1,113 @@
+"""
+Tests that callback_handlers.py uses sanitize_error() instead of str(e).
+
+Verifies the callback_handlers module no longer exposes raw exception
+text in user-facing messages.
+"""
+
+import re
+
+import pytest
+
+
+class TestCallbackHandlersNoStrE:
+    """Verify callback_handlers.py does not pass str(e) to user messages."""
+
+    def _read_source(self) -> str:
+        """Read the callback_handlers.py source."""
+        from pathlib import Path
+
+        src = (
+            Path(__file__).resolve().parent.parent.parent
+            / "src"
+            / "bot"
+            / "callback_handlers.py"
+        )
+        return src.read_text()
+
+    def test_no_str_e_in_user_facing_calls(self):
+        """User-facing calls must not contain str(e) anywhere nearby.
+
+        Checks both same-line and multi-line call patterns where str(e)
+        appears as an argument to reply_text / send_message / edit_text.
+        """
+        source = self._read_source()
+
+        # Single-line check
+        user_facing_str_e = []
+        for i, line in enumerate(source.splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("logger.") or stripped.startswith("#"):
+                continue
+            if "str(e)" in line and any(
+                kw in line
+                for kw in ("reply_text", "send_message", "edit_text")
+            ):
+                user_facing_str_e.append((i, stripped))
+
+        # Multi-line check: find str(e) used as argument within 5 lines
+        # of a user-facing call (covers split-line function calls)
+        lines = source.splitlines()
+        call_keywords = ("reply_text", "send_message_sync", "edit_text", "send_message")
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("logger.") or stripped.startswith("#"):
+                continue
+            if "str(e)" not in stripped:
+                continue
+            # Look back up to 5 lines for a user-facing call opener
+            for back in range(1, 6):
+                if i - back < 0:
+                    break
+                prev = lines[i - back].strip()
+                if prev.startswith("logger.") or prev.startswith("#"):
+                    continue
+                if any(kw in prev for kw in call_keywords):
+                    entry = (i + 1, stripped)
+                    if entry not in user_facing_str_e:
+                        user_facing_str_e.append(entry)
+                    break
+
+        assert user_facing_str_e == [], (
+            f"callback_handlers.py still has str(e) in user-facing messages "
+            f"at lines: {[ln for ln, _ in user_facing_str_e]}"
+        )
+
+    def test_no_raw_error_msg_in_user_messages(self):
+        """User messages must not contain {error_msg} pattern (from str(e))."""
+        source = self._read_source()
+        user_facing_error_msg = []
+        for i, line in enumerate(source.splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("logger."):
+                continue
+            if stripped.startswith("#"):
+                continue
+            # Check for f-string patterns with error_msg in user-facing calls
+            if ("reply_text" in line or "edit_text" in line) and "error_msg" in line:
+                # Allow if it's just the DEBUG_MODE block
+                pass  # We check below more specifically
+            if (
+                ("reply_text" in line or "send_message_sync" in line)
+                and "{error_msg}" in line
+            ):
+                user_facing_error_msg.append((i, stripped))
+
+        assert user_facing_error_msg == [], (
+            f"callback_handlers.py has {{error_msg}} in user messages "
+            f"at lines: {[ln for ln, _ in user_facing_error_msg]}"
+        )
+
+    def test_imports_sanitize_error(self):
+        """callback_handlers.py should import sanitize_error."""
+        source = self._read_source()
+        assert "sanitize_error" in source, (
+            "callback_handlers.py does not import sanitize_error"
+        )
+
+    def test_debug_mode_still_allowed(self):
+        """DEBUG_MODE blocks may show details -- that is intentional."""
+        source = self._read_source()
+        # The DEBUG_MODE block in handle_reanalyze_callback is OK
+        # Just verify it exists and is guarded
+        assert "DEBUG_MODE" in source, "DEBUG_MODE guard should still exist"

--- a/tests/test_bot/test_handler_error_sanitization.py
+++ b/tests/test_bot/test_handler_error_sanitization.py
@@ -1,0 +1,146 @@
+"""
+Tests that handler files use sanitize_error() instead of str(e) in user messages.
+
+Covers srs_handlers.py, poll_handlers.py, note_commands.py, claude_commands.py,
+message_handlers.py, and processor files.
+"""
+
+from pathlib import Path
+
+import pytest
+
+# Base path for the source tree
+_SRC = Path(__file__).resolve().parent.parent.parent / "src"
+
+
+def _read(rel_path: str) -> str:
+    """Read a source file relative to src/."""
+    return (_SRC / rel_path).read_text()
+
+
+def _find_str_e_in_user_messages(source: str) -> list[tuple[int, str]]:
+    """Find lines where str(e) appears in user-facing message calls.
+
+    Returns list of (line_number, stripped_line) tuples.
+    Checks both same-line and multi-line patterns.
+    """
+    hits = []
+    lines = source.splitlines()
+    call_keywords = (
+        "reply_text",
+        "send_message_sync",
+        "edit_message_sync",
+        "edit_text",
+        "send_message",
+    )
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("logger.") or stripped.startswith("#"):
+            continue
+        if "str(e)" not in stripped:
+            continue
+
+        # Same-line check
+        if any(kw in line for kw in call_keywords):
+            hits.append((i + 1, stripped))
+            continue
+
+        # Multi-line: look back up to 5 lines for a user-facing call
+        for back in range(1, 6):
+            if i - back < 0:
+                break
+            prev = lines[i - back].strip()
+            if prev.startswith("logger.") or prev.startswith("#"):
+                continue
+            if any(kw in prev for kw in call_keywords):
+                hits.append((i + 1, stripped))
+                break
+
+    return hits
+
+
+class TestSrsHandlersNoStrE:
+    """Verify srs_handlers.py does not leak str(e)."""
+
+    def test_no_str_e_in_user_messages(self):
+        source = _read("bot/handlers/srs_handlers.py")
+        hits = _find_str_e_in_user_messages(source)
+        assert hits == [], (
+            f"srs_handlers.py has str(e) in user messages at lines: "
+            f"{[ln for ln, _ in hits]}"
+        )
+
+    def test_imports_sanitize_error(self):
+        source = _read("bot/handlers/srs_handlers.py")
+        assert "sanitize_error" in source
+
+
+class TestPollHandlersNoStrE:
+    """Verify poll_handlers.py does not leak str(e)."""
+
+    def test_no_str_e_in_user_messages(self):
+        source = _read("bot/handlers/poll_handlers.py")
+        hits = _find_str_e_in_user_messages(source)
+        assert hits == [], (
+            f"poll_handlers.py has str(e) in user messages at lines: "
+            f"{[ln for ln, _ in hits]}"
+        )
+
+
+class TestNoteCommandsNoStrE:
+    """Verify note_commands.py does not leak str(e)."""
+
+    def test_no_str_e_in_user_messages(self):
+        source = _read("bot/handlers/note_commands.py")
+        hits = _find_str_e_in_user_messages(source)
+        assert hits == [], (
+            f"note_commands.py has str(e) in user messages at lines: "
+            f"{[ln for ln, _ in hits]}"
+        )
+
+
+class TestClaudeCommandsNoStrE:
+    """Verify claude_commands.py does not leak str(e)."""
+
+    def test_no_str_e_in_user_messages(self):
+        source = _read("bot/handlers/claude_commands.py")
+        hits = _find_str_e_in_user_messages(source)
+        assert hits == [], (
+            f"claude_commands.py has str(e) in user messages at lines: "
+            f"{[ln for ln, _ in hits]}"
+        )
+
+
+class TestMessageHandlersNoStrE:
+    """Verify message_handlers.py does not leak str(e)."""
+
+    def test_no_str_e_in_user_messages(self):
+        source = _read("bot/message_handlers.py")
+        hits = _find_str_e_in_user_messages(source)
+        assert hits == [], (
+            f"message_handlers.py has str(e) in user messages at lines: "
+            f"{[ln for ln, _ in hits]}"
+        )
+
+
+class TestProcessorFilesNoStrE:
+    """Verify processor files do not leak str(e)."""
+
+    @pytest.mark.parametrize(
+        "rel_path",
+        [
+            "bot/processors/text.py",
+            "bot/processors/media.py",
+            "bot/processors/content.py",
+            "bot/processors/router.py",
+            "bot/processors/collect.py",
+        ],
+    )
+    def test_no_str_e_in_user_messages(self, rel_path):
+        source = _read(rel_path)
+        hits = _find_str_e_in_user_messages(source)
+        assert hits == [], (
+            f"{rel_path} has str(e) in user messages at lines: "
+            f"{[ln for ln, _ in hits]}"
+        )

--- a/tests/test_bot/test_message_handlers.py
+++ b/tests/test_bot/test_message_handlers.py
@@ -1520,7 +1520,8 @@ class TestErrorHandling:
 
                     processing_msg.edit_text.assert_called()
                     call_args = processing_msg.edit_text.call_args[0][0]
-                    assert "Rate Limit" in call_args
+                    # sanitize_error maps rate-limit keywords to friendly message
+                    assert "wait" in call_args.lower() or "try again" in call_args.lower()
 
     @pytest.mark.asyncio
     async def test_timeout_error_shows_specific_message(
@@ -1552,7 +1553,8 @@ class TestErrorHandling:
 
                     processing_msg.edit_text.assert_called()
                     call_args = processing_msg.edit_text.call_args[0][0]
-                    assert "Timeout" in call_args
+                    # sanitize_error maps timeout keywords to friendly message
+                    assert "too long" in call_args.lower() or "try again" in call_args.lower()
 
     @pytest.mark.asyncio
     async def test_connection_error_shows_specific_message(
@@ -1584,7 +1586,8 @@ class TestErrorHandling:
 
                     processing_msg.edit_text.assert_called()
                     call_args = processing_msg.edit_text.call_args[0][0]
-                    assert "Connection" in call_args
+                    # sanitize_error maps connection keywords to friendly message
+                    assert "connect" in call_args.lower() or "service" in call_args.lower()
 
 
 # =============================================================================

--- a/tests/test_core/test_error_messages.py
+++ b/tests/test_core/test_error_messages.py
@@ -1,0 +1,165 @@
+"""
+Tests for error message sanitization.
+
+Ensures raw exception details never leak to Telegram users.
+"""
+
+import pytest
+
+
+class TestSanitizeError:
+    """Test that sanitize_error() maps exceptions to friendly messages."""
+
+    def test_returns_string(self):
+        """sanitize_error should always return a string."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(ValueError("anything"))
+        assert isinstance(result, str)
+
+    def test_never_leaks_raw_exception_message(self):
+        """Raw exception text like file paths must not appear in output."""
+        from src.core.error_messages import sanitize_error
+
+        secret = "/etc/secrets/api_key.json"
+        result = sanitize_error(ValueError(secret))
+        assert secret not in result
+
+    def test_never_leaks_traceback_info(self):
+        """Stack trace fragments must not appear in output."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(
+            RuntimeError("Traceback (most recent call last): File /app/main.py")
+        )
+        assert "/app/main.py" not in result
+        assert "Traceback" not in result
+
+    def test_maps_connection_error(self):
+        """ConnectionError should produce a connectivity-related message."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(ConnectionError("Failed to connect to 10.0.0.1:5432"))
+        assert "10.0.0.1" not in result
+        assert "connection" in result.lower() or "service" in result.lower()
+
+    def test_maps_timeout_error(self):
+        """TimeoutError should produce a timeout-related message."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(TimeoutError("Read timed out after 30s"))
+        assert "30s" not in result
+        assert "timeout" in result.lower() or "too long" in result.lower()
+
+    def test_maps_permission_error(self):
+        """PermissionError should produce a generic message, not expose paths."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(
+            PermissionError("[Errno 13] Permission denied: '/var/data/db.sqlite'")
+        )
+        assert "/var/data" not in result
+        assert "Errno 13" not in result
+
+    def test_maps_file_not_found_error(self):
+        """FileNotFoundError should produce a generic not-found message."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(
+            FileNotFoundError("[Errno 2] No such file: '/secret/path/data.json'")
+        )
+        assert "/secret/path" not in result
+
+    def test_maps_value_error(self):
+        """ValueError should produce a generic message."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(ValueError("invalid literal for int(): 'abc'"))
+        assert "invalid literal" not in result
+
+    def test_maps_key_error(self):
+        """KeyError should produce a generic message, not the key name."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(KeyError("secret_api_token"))
+        assert "secret_api_token" not in result
+
+    def test_maps_generic_exception(self):
+        """Unknown exception types should produce a safe fallback message."""
+        from src.core.error_messages import sanitize_error
+
+        class CustomInternalError(Exception):
+            pass
+
+        result = sanitize_error(
+            CustomInternalError("internal detail: database schema mismatch v3->v4")
+        )
+        assert "schema mismatch" not in result
+        assert "v3->v4" not in result
+
+    def test_default_message_is_user_friendly(self):
+        """The fallback message should be polite and actionable."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(Exception("anything"))
+        assert "sorry" in result.lower() or "try again" in result.lower()
+
+    def test_none_exception_returns_fallback(self):
+        """Passing None should not crash, returns fallback."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(None)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_rate_limit_detection(self):
+        """Exceptions with 'rate limit' in message get appropriate response."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(Exception("rate limit exceeded for user 12345"))
+        assert "12345" not in result
+        assert "rate" in result.lower() or "wait" in result.lower() or "try again" in result.lower()
+
+    def test_authentication_error_detection(self):
+        """Exceptions mentioning auth/api_key get appropriate response."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(
+            Exception("AuthenticationError: invalid api_key sk-abc123xyz")
+        )
+        assert "sk-abc123xyz" not in result
+        assert "api_key" not in result.lower() or "configuration" in result.lower()
+
+    def test_database_error_detection(self):
+        """Database-related errors get a service message."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(
+            Exception("(sqlite3.OperationalError) database is locked")
+        )
+        assert "database is locked" not in result.lower()
+
+
+class TestSanitizeErrorForContext:
+    """Test context-specific error message formatting."""
+
+    def test_with_context_prefix(self):
+        """sanitize_error with context should include the context description."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(
+            TimeoutError("connection timed out"),
+            context="processing your image",
+        )
+        assert "image" in result.lower()
+
+    def test_context_does_not_leak_exception(self):
+        """Even with context, raw exception must not leak."""
+        from src.core.error_messages import sanitize_error
+
+        result = sanitize_error(
+            ValueError("/Users/admin/.ssh/id_rsa"),
+            context="reading file",
+        )
+        assert "/Users/admin" not in result
+        assert "id_rsa" not in result


### PR DESCRIPTION
## Summary
- Added `src/core/error_messages.py` error sanitization module
- Updated callback_handlers to use sanitized error messages
- WIP: agent still running for slice 3 (remaining handlers)

Closes #209

## Test plan
- [ ] Error sanitizer unit tests pass
- [ ] No raw exception text in user-facing messages
- [ ] Callback error messages are context-specific

🤖 Generated with [Claude Code](https://claude.com/claude-code)