### PR TITLE
refactor: Extract business logic from handlers into services (#218)

### DIFF
--- a/src/bot/handlers/claude_commands.py
+++ b/src/bot/handlers/claude_commands.py
@@ -49,44 +49,13 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
-# New Session Trigger Detection (#14)
+# New Session Trigger Detection (#14) — delegated to service layer
 # =============================================================================
 
-# Trigger phrases that start a new session (case-insensitive)
-NEW_SESSION_TRIGGERS = [
-    "new session",
-    "start new session",
-    "fresh session",
-    "новая сессия",  # Russian
-]
-
-
-def detect_new_session_trigger(text: str) -> dict:
-    """
-    Detect if text starts with a 'new session' trigger phrase.
-
-    Args:
-        text: The message text to check
-
-    Returns:
-        dict with:
-            - triggered: bool - True if trigger phrase detected
-            - prompt: str - Text after the trigger phrase (or original text if not triggered)
-    """
-    if not text:
-        return {"triggered": False, "prompt": text or ""}
-
-    text_lower = text.lower().strip()
-
-    for trigger in NEW_SESSION_TRIGGERS:
-        if text_lower.startswith(trigger):
-            # Extract the prompt after the trigger phrase
-            remainder = text[len(trigger) :].strip()
-            # Handle newlines - take everything after trigger
-            remainder = remainder.lstrip("\n").strip()
-            return {"triggered": True, "prompt": remainder}
-
-    return {"triggered": False, "prompt": text}
+from ...services.session_service import (  # noqa: E402
+    NEW_SESSION_TRIGGERS,
+    detect_new_session_trigger,
+)
 
 
 def _format_work_summary(stats: dict, locale: str = "en") -> str:

--- a/src/bot/handlers/claude_commands.py
+++ b/src/bot/handlers/claude_commands.py
@@ -58,57 +58,9 @@ from ...services.session_service import (  # noqa: E402
 )
 
 
-def _format_work_summary(stats: dict, locale: str = "en") -> str:
-    """Format work statistics into human-readable summary."""
-    if not stats:
-        return ""
-
-    from ...core.i18n import t
-
-    parts = []
-
-    # Duration
-    duration = stats.get("duration", "")
-    if duration:
-        parts.append(f"⏱️ {duration}")
-
-    # Tool usage summary
-    tool_counts = stats.get("tool_counts", {})
-    if tool_counts:
-        # Format key tools
-        tool_summary = []
-        if tool_counts.get("Read"):
-            c = tool_counts["Read"]
-            tool_summary.append("📖 " + t("claude.tool_reads", locale, count=c))
-        if tool_counts.get("Write") or tool_counts.get("Edit"):
-            c = tool_counts.get("Write", 0) + tool_counts.get("Edit", 0)
-            tool_summary.append("✍️ " + t("claude.tool_edits", locale, count=c))
-        if tool_counts.get("Grep") or tool_counts.get("Glob"):
-            c = tool_counts.get("Grep", 0) + tool_counts.get("Glob", 0)
-            tool_summary.append("🔍 " + t("claude.tool_searches", locale, count=c))
-        if tool_counts.get("Bash"):
-            c = tool_counts["Bash"]
-            tool_summary.append("⚡ " + t("claude.tool_commands", locale, count=c))
-
-        if tool_summary:
-            parts.append(" · ".join(tool_summary))
-
-    # Web activity
-    web_fetches = stats.get("web_fetches", [])
-    if web_fetches:
-        c = len(web_fetches)
-        parts.append("🌐 " + t("claude.tool_web_fetches", locale, count=c))
-
-    # Skills used
-    skills = stats.get("skills_used", [])
-    if skills:
-        skills_str = ", ".join(skills)
-        parts.append("🎯 " + t("claude.tool_skills", locale, skills=skills_str))
-
-    if not parts:
-        return ""
-
-    return "\n\n<i>" + " · ".join(parts) + "</i>"
+from ...services.work_summary_service import (  # noqa: E402
+    format_work_summary as _format_work_summary,
+)
 
 
 async def claude_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/src/services/session_service.py
+++ b/src/services/session_service.py
@@ -1,0 +1,46 @@
+"""
+Session service — business logic for session trigger detection.
+
+Extracted from src/bot/handlers/claude_commands.py (#218).
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Trigger phrases that start a new session (case-insensitive)
+NEW_SESSION_TRIGGERS = [
+    "new session",
+    "start new session",
+    "fresh session",
+    "новая сессия",  # Russian
+]
+
+
+def detect_new_session_trigger(text: Optional[str]) -> dict:
+    """
+    Detect if text starts with a 'new session' trigger phrase.
+
+    Args:
+        text: The message text to check
+
+    Returns:
+        dict with:
+            - triggered: bool - True if trigger phrase detected
+            - prompt: str - Text after the trigger phrase (or original text)
+    """
+    if not text:
+        return {"triggered": False, "prompt": text or ""}
+
+    text_lower = text.lower().strip()
+
+    for trigger in NEW_SESSION_TRIGGERS:
+        if text_lower.startswith(trigger):
+            # Extract the prompt after the trigger phrase
+            remainder = text[len(trigger) :].strip()
+            # Handle newlines - take everything after trigger
+            remainder = remainder.lstrip("\n").strip()
+            return {"triggered": True, "prompt": remainder}
+
+    return {"triggered": False, "prompt": text}

--- a/src/services/work_summary_service.py
+++ b/src/services/work_summary_service.py
@@ -1,0 +1,73 @@
+"""
+Work summary service — format Claude work statistics for display.
+
+Extracted from src/bot/handlers/claude_commands.py (#218).
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def format_work_summary(stats: Optional[dict], locale: str = "en") -> str:
+    """Format work statistics into human-readable summary.
+
+    Args:
+        stats: Dictionary with keys like duration, tool_counts, web_fetches,
+               skills_used.
+        locale: Locale code for i18n translations.
+
+    Returns:
+        HTML-formatted summary string, or empty string if no stats.
+    """
+    if not stats:
+        return ""
+
+    from ..core.i18n import t
+
+    parts = []
+
+    # Duration
+    duration = stats.get("duration", "")
+    if duration:
+        parts.append(f"\u23f1\ufe0f {duration}")
+
+    # Tool usage summary
+    tool_counts = stats.get("tool_counts", {})
+    if tool_counts:
+        tool_summary = []
+        if tool_counts.get("Read"):
+            c = tool_counts["Read"]
+            tool_summary.append("\U0001f4d6 " + t("claude.tool_reads", locale, count=c))
+        if tool_counts.get("Write") or tool_counts.get("Edit"):
+            c = tool_counts.get("Write", 0) + tool_counts.get("Edit", 0)
+            tool_summary.append("\u270d\ufe0f " + t("claude.tool_edits", locale, count=c))
+        if tool_counts.get("Grep") or tool_counts.get("Glob"):
+            c = tool_counts.get("Grep", 0) + tool_counts.get("Glob", 0)
+            tool_summary.append(
+                "\U0001f50d " + t("claude.tool_searches", locale, count=c)
+            )
+        if tool_counts.get("Bash"):
+            c = tool_counts["Bash"]
+            tool_summary.append("\u26a1 " + t("claude.tool_commands", locale, count=c))
+
+        if tool_summary:
+            parts.append(" \u00b7 ".join(tool_summary))
+
+    # Web activity
+    web_fetches = stats.get("web_fetches", [])
+    if web_fetches:
+        c = len(web_fetches)
+        parts.append("\U0001f310 " + t("claude.tool_web_fetches", locale, count=c))
+
+    # Skills used
+    skills = stats.get("skills_used", [])
+    if skills:
+        skills_str = ", ".join(skills)
+        parts.append("\U0001f3af " + t("claude.tool_skills", locale, skills=skills_str))
+
+    if not parts:
+        return ""
+
+    return "\n\n<i>" + " \u00b7 ".join(parts) + "</i>"

--- a/tests/test_services/test_handler_service_integration.py
+++ b/tests/test_services/test_handler_service_integration.py
@@ -1,0 +1,97 @@
+"""
+Tests for handler-service integration — verify handlers call service layer.
+
+Ensures:
+- claude_commands.py uses service-layer imports for business logic
+- The module-level re-exports for backwards compat don't introduce circular deps
+- forward_voice_to_claude uses service-layer detect_new_session_trigger
+"""
+
+import ast
+import inspect
+
+
+class TestHandlerUsesServiceImports:
+    """Verify that handler functions reference service-layer functions."""
+
+    def test_format_work_summary_called_via_service(self):
+        """execute_claude_prompt should call format_work_summary from service."""
+        from src.services.work_summary_service import format_work_summary
+
+        # Verify the service function is the canonical one
+        assert format_work_summary.__module__ == "src.services.work_summary_service"
+
+    def test_detect_trigger_called_via_service(self):
+        """forward_voice_to_claude should use detect_new_session_trigger from service."""
+        from src.services.session_service import detect_new_session_trigger
+
+        assert (
+            detect_new_session_trigger.__module__ == "src.services.session_service"
+        )
+
+    def test_handler_module_imports_from_services(self):
+        """claude_commands.py should have imports from services at module level."""
+        import src.bot.handlers.claude_commands as mod
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        service_imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module and "services" in node.module:
+                    for alias in node.names:
+                        service_imports.append(alias.name)
+
+        # Should import from service modules
+        assert "detect_new_session_trigger" in service_imports
+        assert "format_work_summary" in service_imports or any(
+            "format_work_summary" in name for name in service_imports
+        )
+
+    def test_no_duplicate_business_logic_in_handler(self):
+        """Handler should not contain the body of detect_new_session_trigger."""
+        import src.bot.handlers.claude_commands as mod
+
+        source = inspect.getsource(mod)
+
+        # The handler should NOT define detect_new_session_trigger locally
+        # It should only import it from the service
+        tree = ast.parse(source)
+        function_defs = [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        assert "detect_new_session_trigger" not in function_defs
+
+    def test_no_duplicate_format_work_summary_in_handler(self):
+        """Handler should not contain the body of _format_work_summary."""
+        import src.bot.handlers.claude_commands as mod
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+        function_defs = [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        assert "_format_work_summary" not in function_defs
+
+
+class TestServiceModulesStandalone:
+    """Service modules should work independently of handler layer."""
+
+    def test_session_service_no_handler_import(self):
+        """session_service should not import from bot.handlers."""
+        import src.services.session_service as mod
+
+        source = inspect.getsource(mod)
+        assert "bot.handlers" not in source
+
+    def test_work_summary_service_no_handler_import(self):
+        """work_summary_service should not import from bot.handlers."""
+        import src.services.work_summary_service as mod
+
+        source = inspect.getsource(mod)
+        assert "bot.handlers" not in source

--- a/tests/test_services/test_session_service.py
+++ b/tests/test_services/test_session_service.py
@@ -1,0 +1,142 @@
+"""
+Tests for session_service — business logic extracted from handler layer.
+
+Covers:
+- detect_new_session_trigger() — trigger phrase detection
+- NEW_SESSION_TRIGGERS constant availability
+"""
+
+import pytest
+
+
+# =============================================================================
+# detect_new_session_trigger
+# =============================================================================
+
+
+class TestDetectNewSessionTrigger:
+    """Test detection of 'new session' trigger phrase (service layer)."""
+
+    def test_import_from_service(self):
+        """Function should be importable from services.session_service."""
+        from src.services.session_service import detect_new_session_trigger
+
+        assert callable(detect_new_session_trigger)
+
+    def test_triggers_constant_importable(self):
+        """NEW_SESSION_TRIGGERS should be importable from service."""
+        from src.services.session_service import NEW_SESSION_TRIGGERS
+
+        assert isinstance(NEW_SESSION_TRIGGERS, list)
+        assert len(NEW_SESSION_TRIGGERS) > 0
+
+    def test_detects_new_session_at_start(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("new session help me write code")
+        assert result["triggered"] is True
+        assert result["prompt"] == "help me write code"
+
+    def test_detects_case_insensitive(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        assert detect_new_session_trigger("New Session hello")["triggered"] is True
+        assert detect_new_session_trigger("NEW SESSION hello")["triggered"] is True
+
+    def test_extracts_prompt_after_trigger(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("new session Write a poem about cats")
+        assert result["prompt"] == "Write a poem about cats"
+
+    def test_trigger_without_prompt(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("new session")
+        assert result["triggered"] is True
+        assert result["prompt"] == ""
+
+    def test_trigger_with_only_whitespace(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("new session   ")
+        assert result["triggered"] is True
+        assert result["prompt"] == ""
+
+    def test_no_trigger_when_not_at_start(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("please start a new session")
+        assert result["triggered"] is False
+
+    def test_no_trigger_for_normal_text(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("help me write code")
+        assert result["triggered"] is False
+
+    def test_handles_newline_after_trigger(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("new session\nWrite a function")
+        assert result["triggered"] is True
+        assert result["prompt"] == "Write a function"
+
+    def test_handles_empty_text(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("")
+        assert result["triggered"] is False
+        assert result["prompt"] == ""
+
+    def test_handles_none_text(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger(None)
+        assert result["triggered"] is False
+        assert result["prompt"] == ""
+
+    def test_detects_start_new_session(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("start new session help me")
+        assert result["triggered"] is True
+        assert result["prompt"] == "help me"
+
+    def test_detects_fresh_session(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("fresh session build an API")
+        assert result["triggered"] is True
+        assert result["prompt"] == "build an API"
+
+    def test_detects_russian_trigger(self):
+        from src.services.session_service import detect_new_session_trigger
+
+        result = detect_new_session_trigger("новая сессия напиши код")
+        assert result["triggered"] is True
+        assert result["prompt"] == "напиши код"
+
+
+class TestBackwardsCompatibility:
+    """The old import path should still work via re-export."""
+
+    def test_old_import_still_works(self):
+        from src.bot.handlers.claude_commands import detect_new_session_trigger
+
+        assert callable(detect_new_session_trigger)
+
+    def test_old_triggers_constant_still_works(self):
+        from src.bot.handlers.claude_commands import NEW_SESSION_TRIGGERS
+
+        assert isinstance(NEW_SESSION_TRIGGERS, list)
+
+    def test_old_and_new_are_same_function(self):
+        from src.bot.handlers.claude_commands import (
+            detect_new_session_trigger as old_fn,
+        )
+        from src.services.session_service import (
+            detect_new_session_trigger as new_fn,
+        )
+
+        assert old_fn is new_fn

--- a/tests/test_services/test_work_summary_service.py
+++ b/tests/test_services/test_work_summary_service.py
@@ -1,0 +1,195 @@
+"""
+Tests for work_summary_service — formatting work statistics.
+
+Extracted from handler layer (#218).
+"""
+
+import pytest
+
+
+class TestFormatWorkSummary:
+    """Tests for format_work_summary function in service layer."""
+
+    def test_import_from_service(self):
+        """Function should be importable from services.work_summary_service."""
+        from src.services.work_summary_service import format_work_summary
+
+        assert callable(format_work_summary)
+
+    def test_empty_stats(self):
+        from src.services.work_summary_service import format_work_summary
+
+        assert format_work_summary({}) == ""
+
+    def test_none_stats(self):
+        from src.services.work_summary_service import format_work_summary
+
+        assert format_work_summary(None) == ""
+
+    def test_duration_only(self):
+        from src.services.work_summary_service import format_work_summary
+
+        result = format_work_summary({"duration": "45s"})
+        assert "45s" in result
+        assert "<i>" in result
+        assert "</i>" in result
+
+    def test_duration_minutes(self):
+        from src.services.work_summary_service import format_work_summary
+
+        result = format_work_summary({"duration": "2m 30s"})
+        assert "2m 30s" in result
+
+    def test_read_tools(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "30s", "tool_counts": {"Read": 5}}
+        result = format_work_summary(stats)
+        assert "5 reads" in result
+
+    def test_write_tools(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "30s", "tool_counts": {"Write": 2}}
+        result = format_work_summary(stats)
+        assert "2 edits" in result
+
+    def test_edit_tools(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "30s", "tool_counts": {"Edit": 3}}
+        result = format_work_summary(stats)
+        assert "3 edits" in result
+
+    def test_write_and_edit_combined(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "30s", "tool_counts": {"Write": 2, "Edit": 3}}
+        result = format_work_summary(stats)
+        assert "5 edits" in result
+
+    def test_search_tools(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "30s", "tool_counts": {"Grep": 4, "Glob": 2}}
+        result = format_work_summary(stats)
+        assert "6 searches" in result
+
+    def test_bash_commands(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "30s", "tool_counts": {"Bash": 7}}
+        result = format_work_summary(stats)
+        assert "7 commands" in result
+
+    def test_web_fetches(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {
+            "duration": "1m 0s",
+            "web_fetches": [
+                "https://example.com",
+                "https://docs.python.org",
+                "search: AI research",
+            ],
+        }
+        result = format_work_summary(stats)
+        assert "3 web fetches" in result
+
+    def test_skills_used(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {
+            "duration": "2m 15s",
+            "skills_used": ["tavily-search", "pdf-generation"],
+        }
+        result = format_work_summary(stats)
+        assert "Skills:" in result
+        assert "tavily-search" in result
+        assert "pdf-generation" in result
+
+    def test_full_stats(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {
+            "duration": "3m 45s",
+            "tool_counts": {
+                "Read": 10,
+                "Write": 3,
+                "Edit": 5,
+                "Grep": 8,
+                "Glob": 2,
+                "Bash": 4,
+            },
+            "web_fetches": ["https://example.com"],
+            "skills_used": ["deep-research"],
+            "bash_commands": ["npm install", "npm test"],
+        }
+        result = format_work_summary(stats)
+        assert "3m 45s" in result
+        assert "10 reads" in result
+        assert "8 edits" in result
+        assert "10 searches" in result
+        assert "4 commands" in result
+        assert "1 web fetch" in result
+        assert "deep-research" in result
+        assert "</i>" in result
+        assert " · " in result
+
+    def test_empty_tool_counts(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "10s", "tool_counts": {}}
+        result = format_work_summary(stats)
+        assert "10s" in result
+        assert "reads" not in result
+
+    def test_zero_counts_ignored(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "10s", "tool_counts": {"Read": 0, "Write": 0, "Bash": 3}}
+        result = format_work_summary(stats)
+        assert "3 commands" in result
+        assert "reads" not in result
+        assert "edits" not in result
+
+    def test_empty_web_fetches(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "10s", "web_fetches": []}
+        result = format_work_summary(stats)
+        assert "web fetch" not in result
+
+    def test_empty_skills(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"duration": "10s", "skills_used": []}
+        result = format_work_summary(stats)
+        assert "Skills" not in result
+
+    def test_no_duration(self):
+        from src.services.work_summary_service import format_work_summary
+
+        stats = {"tool_counts": {"Read": 3}}
+        result = format_work_summary(stats)
+        assert "3 reads" in result
+        assert "⏱" not in result
+
+
+class TestBackwardsCompatFormatWorkSummary:
+    """The old import path should still work via re-export."""
+
+    def test_old_import_still_works(self):
+        from src.bot.handlers.claude_commands import _format_work_summary
+
+        assert callable(_format_work_summary)
+
+    def test_old_and_new_are_same_function(self):
+        from src.bot.handlers.claude_commands import (
+            _format_work_summary as old_fn,
+        )
+        from src.services.work_summary_service import (
+            format_work_summary as new_fn,
+        )
+
+        assert old_fn is new_fn


### PR DESCRIPTION
## Summary
- Moved detect_new_session_trigger() to src/services/session_service.py
- Moved _format_work_summary to src/services/work_summary_service.py
- Added handler-service integration tests

Closes #218

## Test plan
- [x] Service tests pass in isolation
- [x] Integration tests verify handler-service wiring
- [ ] Claude session creation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)