### PR TITLE
feat: Add typed domain errors module (#227)

### DIFF
--- a/src/domain/errors.py
+++ b/src/domain/errors.py
@@ -1,0 +1,57 @@
+"""
+Typed domain errors for the Telegram Agent.
+
+These replace bare except/return None patterns so callers can distinguish
+specific failure modes (missing settings vs. missing tracker vs. TTS failure)
+and map each to an appropriate user-facing message.
+"""
+
+
+class DomainError(Exception):
+    """Base class for all domain-specific errors."""
+
+
+# ---------------------------------------------------------------------------
+# Accountability domain
+# ---------------------------------------------------------------------------
+
+
+class UserSettingsNotFound(DomainError):
+    """No UserSettings row exists for the given user."""
+
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
+        super().__init__(f"No settings found for user {user_id}")
+
+
+class TrackerNotFound(DomainError):
+    """Tracker with the given ID does not exist."""
+
+    def __init__(self, tracker_id: int) -> None:
+        self.tracker_id = tracker_id
+        super().__init__(f"Tracker {tracker_id} not found")
+
+
+class VoiceSynthesisFailure(DomainError):
+    """TTS provider returned an error or timed out."""
+
+
+# ---------------------------------------------------------------------------
+# Poll domain
+# ---------------------------------------------------------------------------
+
+
+class PollNotTracked(DomainError):
+    """Received an answer for a poll we are not tracking."""
+
+    def __init__(self, poll_id: str) -> None:
+        self.poll_id = poll_id
+        super().__init__(f"Received answer for untracked poll: {poll_id}")
+
+
+class PollSendFailure(DomainError):
+    """Failed to send a poll via the Telegram API."""
+
+
+class EmbeddingFailure(DomainError):
+    """Embedding generation failed (model not loaded, OOM, etc.)."""

--- a/tests/test_domain/test_errors.py
+++ b/tests/test_domain/test_errors.py
@@ -1,0 +1,76 @@
+"""
+Tests for typed domain errors.
+
+Verifies that each error class exists, inherits correctly,
+and carries the right attributes for downstream handling.
+"""
+
+import pytest
+
+
+class TestDomainErrorHierarchy:
+    """All domain errors inherit from a common base."""
+
+    def test_base_error_exists(self):
+        from src.domain.errors import DomainError
+
+        assert issubclass(DomainError, Exception)
+
+    def test_base_error_carries_message(self):
+        from src.domain.errors import DomainError
+
+        err = DomainError("something broke")
+        assert str(err) == "something broke"
+
+
+class TestAccountabilityErrors:
+    """Errors raised by accountability_service."""
+
+    def test_user_settings_not_found(self):
+        from src.domain.errors import DomainError, UserSettingsNotFound
+
+        assert issubclass(UserSettingsNotFound, DomainError)
+        err = UserSettingsNotFound(user_id=42)
+        assert err.user_id == 42
+        assert "42" in str(err)
+
+    def test_tracker_not_found(self):
+        from src.domain.errors import DomainError, TrackerNotFound
+
+        assert issubclass(TrackerNotFound, DomainError)
+        err = TrackerNotFound(tracker_id=7)
+        assert err.tracker_id == 7
+        assert "7" in str(err)
+
+    def test_voice_synthesis_failure(self):
+        from src.domain.errors import DomainError, VoiceSynthesisFailure
+
+        assert issubclass(VoiceSynthesisFailure, DomainError)
+        err = VoiceSynthesisFailure("timeout from TTS provider")
+        assert "timeout" in str(err).lower()
+
+
+class TestPollErrors:
+    """Errors raised by poll_service."""
+
+    def test_poll_not_tracked(self):
+        from src.domain.errors import DomainError, PollNotTracked
+
+        assert issubclass(PollNotTracked, DomainError)
+        err = PollNotTracked(poll_id="abc123")
+        assert err.poll_id == "abc123"
+        assert "abc123" in str(err)
+
+    def test_poll_send_failure(self):
+        from src.domain.errors import DomainError, PollSendFailure
+
+        assert issubclass(PollSendFailure, DomainError)
+        err = PollSendFailure("Telegram API 429")
+        assert "429" in str(err)
+
+    def test_embedding_failure(self):
+        from src.domain.errors import DomainError, EmbeddingFailure
+
+        assert issubclass(EmbeddingFailure, DomainError)
+        err = EmbeddingFailure("model not loaded")
+        assert "model not loaded" in str(err)

--- a/tests/test_services/test_accountability_errors.py
+++ b/tests/test_services/test_accountability_errors.py
@@ -1,0 +1,279 @@
+"""
+Tests that accountability_service raises typed domain errors
+instead of silently returning None.
+
+Each test mocks the DB/TTS layer and asserts the specific exception.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.domain.errors import TrackerNotFound, UserSettingsNotFound, VoiceSynthesisFailure
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_db_session(execute_return=None):
+    """Return a mock async context-manager session."""
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = execute_return
+    session.execute = AsyncMock(return_value=result)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# send_check_in
+# ---------------------------------------------------------------------------
+
+
+class TestSendCheckInErrors:
+    """send_check_in must raise typed errors, not return None."""
+
+    @pytest.mark.asyncio
+    async def test_raises_user_settings_not_found(self):
+        """When there are no user settings, raise UserSettingsNotFound."""
+        with patch(
+            "src.services.accountability_service.AccountabilityService.get_user_settings",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            from src.services.accountability_service import AccountabilityService
+
+            with pytest.raises(UserSettingsNotFound) as exc_info:
+                await AccountabilityService.send_check_in(user_id=42, tracker_id=1)
+            assert exc_info.value.user_id == 42
+
+    @pytest.mark.asyncio
+    async def test_raises_tracker_not_found(self):
+        """When the tracker doesn't exist, raise TrackerNotFound."""
+        settings = MagicMock()
+        settings.partner_personality = "supportive"
+        settings.partner_voice_override = None
+
+        with (
+            patch(
+                "src.services.accountability_service.AccountabilityService.get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch(
+                "src.services.accountability_service.get_db_session"
+            ) as mock_db,
+        ):
+            mock_db.return_value = _mock_db_session(execute_return=None)
+
+            from src.services.accountability_service import AccountabilityService
+
+            with pytest.raises(TrackerNotFound) as exc_info:
+                await AccountabilityService.send_check_in(user_id=42, tracker_id=999)
+            assert exc_info.value.tracker_id == 999
+
+    @pytest.mark.asyncio
+    async def test_raises_voice_synthesis_failure(self):
+        """When TTS fails, raise VoiceSynthesisFailure instead of returning None."""
+        settings = MagicMock()
+        settings.partner_personality = "supportive"
+        settings.partner_voice_override = None
+
+        tracker = MagicMock()
+        tracker.name = "Exercise"
+
+        with (
+            patch(
+                "src.services.accountability_service.AccountabilityService.get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch(
+                "src.services.accountability_service.get_db_session"
+            ) as mock_db,
+            patch(
+                "src.services.accountability_service.AccountabilityService.get_streak",
+                new_callable=AsyncMock,
+                return_value=3,
+            ),
+            patch(
+                "src.services.accountability_service.synthesize_voice_mp3",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("TTS provider timeout"),
+            ),
+        ):
+            mock_db.return_value = _mock_db_session(execute_return=tracker)
+
+            from src.services.accountability_service import AccountabilityService
+
+            with pytest.raises(VoiceSynthesisFailure):
+                await AccountabilityService.send_check_in(user_id=42, tracker_id=1)
+
+
+# ---------------------------------------------------------------------------
+# send_struggle_alert
+# ---------------------------------------------------------------------------
+
+
+class TestSendStruggleAlertErrors:
+    """send_struggle_alert must raise typed errors, not return None."""
+
+    @pytest.mark.asyncio
+    async def test_raises_user_settings_not_found(self):
+        with patch(
+            "src.services.accountability_service.AccountabilityService.get_user_settings",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            from src.services.accountability_service import AccountabilityService
+
+            with pytest.raises(UserSettingsNotFound):
+                await AccountabilityService.send_struggle_alert(
+                    user_id=42, tracker_id=1, consecutive_misses=5
+                )
+
+    @pytest.mark.asyncio
+    async def test_raises_tracker_not_found(self):
+        settings = MagicMock()
+        settings.partner_personality = "supportive"
+        settings.partner_voice_override = None
+
+        with (
+            patch(
+                "src.services.accountability_service.AccountabilityService.get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch(
+                "src.services.accountability_service.get_db_session"
+            ) as mock_db,
+        ):
+            mock_db.return_value = _mock_db_session(execute_return=None)
+
+            from src.services.accountability_service import AccountabilityService
+
+            with pytest.raises(TrackerNotFound) as exc_info:
+                await AccountabilityService.send_struggle_alert(
+                    user_id=42, tracker_id=999, consecutive_misses=5
+                )
+            assert exc_info.value.tracker_id == 999
+
+    @pytest.mark.asyncio
+    async def test_raises_voice_synthesis_failure(self):
+        settings = MagicMock()
+        settings.partner_personality = "supportive"
+        settings.partner_voice_override = None
+
+        tracker = MagicMock()
+        tracker.name = "Exercise"
+
+        with (
+            patch(
+                "src.services.accountability_service.AccountabilityService.get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch(
+                "src.services.accountability_service.get_db_session"
+            ) as mock_db,
+            patch(
+                "src.services.accountability_service.synthesize_voice_mp3",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("TTS boom"),
+            ),
+        ):
+            mock_db.return_value = _mock_db_session(execute_return=tracker)
+
+            from src.services.accountability_service import AccountabilityService
+
+            with pytest.raises(VoiceSynthesisFailure):
+                await AccountabilityService.send_struggle_alert(
+                    user_id=42, tracker_id=1, consecutive_misses=5
+                )
+
+
+# ---------------------------------------------------------------------------
+# celebrate_milestone
+# ---------------------------------------------------------------------------
+
+
+class TestCelebrateMilestoneErrors:
+    """celebrate_milestone must raise typed errors, not return None."""
+
+    @pytest.mark.asyncio
+    async def test_raises_user_settings_not_found(self):
+        with patch(
+            "src.services.accountability_service.AccountabilityService.get_user_settings",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            from src.services.accountability_service import AccountabilityService
+
+            with pytest.raises(UserSettingsNotFound):
+                await AccountabilityService.celebrate_milestone(
+                    user_id=42, tracker_id=1, milestone=7
+                )
+
+    @pytest.mark.asyncio
+    async def test_raises_tracker_not_found(self):
+        settings = MagicMock()
+        settings.partner_personality = "supportive"
+        settings.celebration_style = "moderate"
+        settings.partner_voice_override = None
+
+        with (
+            patch(
+                "src.services.accountability_service.AccountabilityService.get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch(
+                "src.services.accountability_service.get_db_session"
+            ) as mock_db,
+        ):
+            mock_db.return_value = _mock_db_session(execute_return=None)
+
+            from src.services.accountability_service import AccountabilityService
+
+            with pytest.raises(TrackerNotFound) as exc_info:
+                await AccountabilityService.celebrate_milestone(
+                    user_id=42, tracker_id=999, milestone=7
+                )
+            assert exc_info.value.tracker_id == 999
+
+    @pytest.mark.asyncio
+    async def test_raises_voice_synthesis_failure(self):
+        settings = MagicMock()
+        settings.partner_personality = "supportive"
+        settings.celebration_style = "moderate"
+        settings.partner_voice_override = None
+
+        tracker = MagicMock()
+        tracker.name = "Exercise"
+
+        with (
+            patch(
+                "src.services.accountability_service.AccountabilityService.get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch(
+                "src.services.accountability_service.get_db_session"
+            ) as mock_db,
+            patch(
+                "src.services.accountability_service.synthesize_voice_mp3",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("TTS error"),
+            ),
+        ):
+            mock_db.return_value = _mock_db_session(execute_return=tracker)
+
+            from src.services.accountability_service import AccountabilityService
+
+            with pytest.raises(VoiceSynthesisFailure):
+                await AccountabilityService.celebrate_milestone(
+                    user_id=42, tracker_id=1, milestone=7
+                )

--- a/tests/test_services/test_poll_errors.py
+++ b/tests/test_services/test_poll_errors.py
@@ -1,0 +1,90 @@
+"""
+Tests that poll_service raises typed domain errors
+instead of silently returning None/False.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.domain.errors import EmbeddingFailure, PollNotTracked, PollSendFailure
+
+
+# ---------------------------------------------------------------------------
+# send_poll
+# ---------------------------------------------------------------------------
+
+
+class TestSendPollErrors:
+    """send_poll must raise PollSendFailure, not return None."""
+
+    @pytest.mark.asyncio
+    async def test_raises_poll_send_failure_on_telegram_error(self):
+        """When bot.send_poll raises, wrap in PollSendFailure."""
+        from src.services.poll_service import PollService
+
+        service = PollService()
+        bot = MagicMock()
+        bot.send_poll = AsyncMock(side_effect=RuntimeError("Telegram 429"))
+
+        template = MagicMock()
+        template.question = "How are you?"
+        template.options = ["Good", "Bad"]
+
+        with pytest.raises(PollSendFailure) as exc_info:
+            await service.send_poll(bot=bot, chat_id=123, template=template)
+        assert "429" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# handle_poll_answer
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePollAnswerErrors:
+    """handle_poll_answer must raise typed errors, not return False."""
+
+    @pytest.mark.asyncio
+    async def test_raises_poll_not_tracked(self):
+        """Unknown poll_id raises PollNotTracked."""
+        from src.services.poll_service import PollService
+
+        service = PollService()
+        # _poll_tracker is empty, so any poll_id is untracked
+
+        with pytest.raises(PollNotTracked) as exc_info:
+            await service.handle_poll_answer(
+                poll_id="unknown_id", user_id=1, selected_option_id=0
+            )
+        assert exc_info.value.poll_id == "unknown_id"
+
+    @pytest.mark.asyncio
+    async def test_raises_embedding_failure(self):
+        """When embedding generation fails, raise EmbeddingFailure."""
+        from src.services.poll_service import PollService
+
+        service = PollService()
+        # Seed the tracker with a known poll
+        service._poll_tracker["poll_123"] = {
+            "template_id": 1,
+            "chat_id": 100,
+            "sent_at": MagicMock(),
+            "question": "How do you feel?",
+            "options": ["Great", "OK", "Bad"],
+            "poll_type": "emotion",
+            "poll_category": "personal",
+            "message_id": 42,
+            "context_data": {},
+        }
+
+        with patch.object(
+            service.embedding_service,
+            "generate_embedding",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("model not loaded"),
+        ):
+            with pytest.raises(EmbeddingFailure) as exc_info:
+                await service.handle_poll_answer(
+                    poll_id="poll_123", user_id=1, selected_option_id=0
+                )
+            assert "model not loaded" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Created `src/domain/errors.py` with typed exceptions
- WIP: agent running for service updates (slices 2-3)

Closes #227

## Test plan
- [ ] Domain errors properly typed and tested
- [ ] Services raise typed errors instead of returning None/False

🤖 Generated with [Claude Code](https://claude.com/claude-code)