### PR TITLE
feat: Add domain events with EventBus and subscribers (#223)

### DIFF
--- a/src/domain/events.py
+++ b/src/domain/events.py
@@ -1,0 +1,102 @@
+"""Domain events for poll/accountability workflows.
+
+Defines event types and a lightweight async EventBus for decoupled
+communication between services.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Type
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Event types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PollAnswered:
+    """Emitted after a poll response is persisted."""
+
+    poll_id: str
+    chat_id: int
+    poll_type: str
+    poll_category: Optional[str]
+    selected_option_id: int
+    selected_option_text: str
+    question: str
+    response_id: int
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class MoodCaptured:
+    """Emitted when a mood-related poll is answered."""
+
+    poll_id: str
+    chat_id: int
+    mood_label: str
+    poll_type: str
+    response_id: int
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+# ---------------------------------------------------------------------------
+# EventBus
+# ---------------------------------------------------------------------------
+
+# Type alias for an async event handler
+EventHandler = Callable[[Any], Coroutine[Any, Any, None]]
+
+
+class EventBus:
+    """Simple in-process async event bus.
+
+    Subscribers register for a specific event type. When that event is
+    published, all registered handlers are invoked. A failing handler
+    logs the error but does not prevent remaining handlers from running.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[Type, List[EventHandler]] = {}
+
+    def subscribe(self, event_type: Type, handler: EventHandler) -> None:
+        """Register *handler* for *event_type*."""
+        self._subscribers.setdefault(event_type, []).append(handler)
+
+    async def publish(self, event: Any) -> None:
+        """Dispatch *event* to all registered handlers for its type."""
+        handlers = self._subscribers.get(type(event), [])
+        for handler in handlers:
+            try:
+                await handler(event)
+            except Exception:
+                logger.exception(
+                    "Event handler %s failed for %s",
+                    getattr(handler, "__name__", handler),
+                    type(event).__name__,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Singleton access
+# ---------------------------------------------------------------------------
+
+_event_bus: Optional[EventBus] = None
+
+
+def get_event_bus() -> EventBus:
+    """Return the global EventBus singleton (create on first call)."""
+    global _event_bus
+    if _event_bus is None:
+        _event_bus = EventBus()
+    return _event_bus
+
+
+def reset_event_bus() -> None:
+    """Replace the global EventBus (useful in tests)."""
+    global _event_bus
+    _event_bus = None

--- a/src/domain/subscribers.py
+++ b/src/domain/subscribers.py
@@ -1,0 +1,69 @@
+"""Event subscribers for poll/accountability workflows.
+
+Subscribers react to domain events and perform side-effects such as
+flipping processed_for_* flags on PollResponse rows and emitting
+secondary events (e.g. MoodCaptured).
+"""
+
+import logging
+from typing import Optional
+
+from sqlalchemy import text
+
+from ..core.database import get_db_session
+from .events import EventBus, MoodCaptured, PollAnswered, get_event_bus
+
+logger = logging.getLogger(__name__)
+
+
+class PollResponseProcessor:
+    """Listens for PollAnswered and flips processed_for flags.
+
+    Also emits MoodCaptured when the poll_type is ``emotion``.
+    """
+
+    def __init__(self, event_bus: Optional[EventBus] = None) -> None:
+        self._event_bus = event_bus or get_event_bus()
+
+    def register(self, bus: EventBus) -> None:
+        """Subscribe to PollAnswered on the given bus."""
+        bus.subscribe(PollAnswered, self.on_poll_answered)
+
+    async def on_poll_answered(self, event: PollAnswered) -> None:
+        """Process a PollAnswered event.
+
+        1. Flip processed_for_trails, processed_for_todos, and
+           processed_for_insights to 1 for the response row.
+        2. If the poll is an emotion type, publish a MoodCaptured event.
+        """
+        async with get_db_session() as session:
+            await session.execute(
+                text(
+                    "UPDATE poll_responses "
+                    "SET processed_for_trails = 1, "
+                    "    processed_for_todos = 1, "
+                    "    processed_for_insights = 1 "
+                    "WHERE id = :rid"
+                ),
+                {"rid": event.response_id},
+            )
+            await session.commit()
+
+        logger.info(
+            "Processed poll response %s (poll_id=%s): flags flipped",
+            event.response_id,
+            event.poll_id,
+        )
+
+        # Emit secondary event for mood tracking
+        if event.poll_type == "emotion":
+            await self._event_bus.publish(
+                MoodCaptured(
+                    poll_id=event.poll_id,
+                    chat_id=event.chat_id,
+                    mood_label=event.selected_option_text,
+                    poll_type=event.poll_type,
+                    response_id=event.response_id,
+                    timestamp=event.timestamp,
+                )
+            )

--- a/tests/test_domain/test_events.py
+++ b/tests/test_domain/test_events.py
@@ -1,0 +1,215 @@
+"""Tests for domain events and EventBus."""
+
+import asyncio
+from datetime import datetime
+
+from src.domain.events import EventBus, MoodCaptured, PollAnswered
+
+
+class TestPollAnsweredEvent:
+    """PollAnswered event dataclass tests."""
+
+    def test_create_poll_answered(self):
+        event = PollAnswered(
+            poll_id="abc123",
+            chat_id=42,
+            poll_type="emotion",
+            poll_category="personal",
+            selected_option_id=2,
+            selected_option_text="Happy",
+            question="How do you feel?",
+            response_id=7,
+            timestamp=datetime(2026, 1, 1, 12, 0),
+        )
+        assert event.poll_id == "abc123"
+        assert event.chat_id == 42
+        assert event.poll_type == "emotion"
+        assert event.poll_category == "personal"
+        assert event.selected_option_id == 2
+        assert event.selected_option_text == "Happy"
+        assert event.question == "How do you feel?"
+        assert event.response_id == 7
+        assert event.timestamp == datetime(2026, 1, 1, 12, 0)
+
+    def test_poll_answered_defaults_timestamp(self):
+        before = datetime.utcnow()
+        event = PollAnswered(
+            poll_id="x",
+            chat_id=1,
+            poll_type="energy",
+            poll_category=None,
+            selected_option_id=0,
+            selected_option_text="Low",
+            question="Energy?",
+            response_id=1,
+        )
+        after = datetime.utcnow()
+        assert before <= event.timestamp <= after
+
+
+class TestMoodCapturedEvent:
+    """MoodCaptured event dataclass tests."""
+
+    def test_create_mood_captured(self):
+        event = MoodCaptured(
+            poll_id="m1",
+            chat_id=42,
+            mood_label="Happy",
+            poll_type="emotion",
+            response_id=5,
+            timestamp=datetime(2026, 2, 1),
+        )
+        assert event.poll_id == "m1"
+        assert event.chat_id == 42
+        assert event.mood_label == "Happy"
+        assert event.poll_type == "emotion"
+        assert event.response_id == 5
+
+    def test_mood_captured_defaults_timestamp(self):
+        before = datetime.utcnow()
+        event = MoodCaptured(
+            poll_id="m2",
+            chat_id=1,
+            mood_label="Sad",
+            poll_type="emotion",
+            response_id=2,
+        )
+        after = datetime.utcnow()
+        assert before <= event.timestamp <= after
+
+
+class TestEventBus:
+    """EventBus subscribe/publish tests."""
+
+    def test_subscribe_and_publish(self):
+        bus = EventBus()
+        received = []
+
+        async def handler(event):
+            received.append(event)
+
+        bus.subscribe(PollAnswered, handler)
+
+        event = PollAnswered(
+            poll_id="p1",
+            chat_id=1,
+            poll_type="emotion",
+            poll_category=None,
+            selected_option_id=0,
+            selected_option_text="Good",
+            question="Mood?",
+            response_id=1,
+        )
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+        assert len(received) == 1
+        assert received[0] is event
+
+    def test_publish_no_subscribers(self):
+        bus = EventBus()
+        event = PollAnswered(
+            poll_id="p2",
+            chat_id=1,
+            poll_type="energy",
+            poll_category=None,
+            selected_option_id=0,
+            selected_option_text="Low",
+            question="Energy?",
+            response_id=1,
+        )
+        # Should not raise
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+
+    def test_multiple_subscribers(self):
+        bus = EventBus()
+        calls_a = []
+        calls_b = []
+
+        async def handler_a(event):
+            calls_a.append(event)
+
+        async def handler_b(event):
+            calls_b.append(event)
+
+        bus.subscribe(PollAnswered, handler_a)
+        bus.subscribe(PollAnswered, handler_b)
+
+        event = PollAnswered(
+            poll_id="p3",
+            chat_id=1,
+            poll_type="emotion",
+            poll_category=None,
+            selected_option_id=0,
+            selected_option_text="OK",
+            question="How?",
+            response_id=1,
+        )
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+        assert len(calls_a) == 1
+        assert len(calls_b) == 1
+
+    def test_different_event_types_isolated(self):
+        bus = EventBus()
+        poll_calls = []
+        mood_calls = []
+
+        async def poll_handler(event):
+            poll_calls.append(event)
+
+        async def mood_handler(event):
+            mood_calls.append(event)
+
+        bus.subscribe(PollAnswered, poll_handler)
+        bus.subscribe(MoodCaptured, mood_handler)
+
+        mood_event = MoodCaptured(
+            poll_id="m1",
+            chat_id=1,
+            mood_label="Great",
+            poll_type="emotion",
+            response_id=1,
+        )
+        asyncio.get_event_loop().run_until_complete(bus.publish(mood_event))
+
+        assert len(poll_calls) == 0
+        assert len(mood_calls) == 1
+
+    def test_subscriber_error_does_not_block_others(self):
+        bus = EventBus()
+        calls = []
+
+        async def bad_handler(event):
+            raise ValueError("boom")
+
+        async def good_handler(event):
+            calls.append(event)
+
+        bus.subscribe(PollAnswered, bad_handler)
+        bus.subscribe(PollAnswered, good_handler)
+
+        event = PollAnswered(
+            poll_id="p4",
+            chat_id=1,
+            poll_type="emotion",
+            poll_category=None,
+            selected_option_id=0,
+            selected_option_text="Fine",
+            question="Feel?",
+            response_id=1,
+        )
+        asyncio.get_event_loop().run_until_complete(bus.publish(event))
+        assert len(calls) == 1
+
+    def test_get_event_bus_singleton(self):
+        from src.domain.events import get_event_bus
+
+        bus1 = get_event_bus()
+        bus2 = get_event_bus()
+        assert bus1 is bus2
+
+    def test_reset_event_bus(self):
+        from src.domain.events import get_event_bus, reset_event_bus
+
+        bus1 = get_event_bus()
+        reset_event_bus()
+        bus2 = get_event_bus()
+        assert bus1 is not bus2

--- a/tests/test_domain/test_poll_service_events.py
+++ b/tests/test_domain/test_poll_service_events.py
@@ -1,0 +1,142 @@
+"""Tests that poll_service emits PollAnswered after persisting a response."""
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.domain.events import EventBus, PollAnswered
+from src.services.poll_service import PollService
+
+
+class TestPollServiceEmitsEvents:
+    """Verify handle_poll_answer publishes PollAnswered on the EventBus."""
+
+    def _make_service(self, event_bus: EventBus) -> PollService:
+        """Create a PollService wired to the given EventBus."""
+        svc = PollService.__new__(PollService)
+        svc.embedding_service = MagicMock()
+        svc.embedding_service.generate_embedding = AsyncMock(return_value=[0.1, 0.2])
+        svc._poll_tracker = {}
+        svc._event_bus = event_bus
+        return svc
+
+    def _seed_tracker(self, svc: PollService, poll_id: str = "poll1") -> None:
+        """Add a tracked poll so handle_poll_answer can find it."""
+        svc._poll_tracker[poll_id] = {
+            "template_id": 1,
+            "chat_id": 100,
+            "sent_at": datetime(2026, 1, 15, 10, 0),
+            "question": "How are you?",
+            "options": ["Great", "OK", "Bad"],
+            "poll_type": "emotion",
+            "poll_category": "personal",
+            "message_id": 555,
+            "context_data": {},
+        }
+
+    def test_handle_poll_answer_emits_poll_answered(self):
+        bus = EventBus()
+        received = []
+
+        async def capture(event):
+            received.append(event)
+
+        bus.subscribe(PollAnswered, capture)
+
+        svc = self._make_service(bus)
+        self._seed_tracker(svc)
+
+        # Mock database session to avoid real DB
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+
+        # We need to make flush set response.id
+        async def fake_flush():
+            pass
+
+        mock_session.flush = AsyncMock(side_effect=fake_flush)
+
+        with patch(
+            "src.services.poll_service.get_db_session",
+            return_value=mock_session,
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                svc.handle_poll_answer("poll1", user_id=42, selected_option_id=0)
+            )
+
+        assert result is True
+        assert len(received) == 1
+        event = received[0]
+        assert isinstance(event, PollAnswered)
+        assert event.poll_id == "poll1"
+        assert event.chat_id == 100
+        assert event.poll_type == "emotion"
+        assert event.poll_category == "personal"
+        assert event.selected_option_id == 0
+        assert event.selected_option_text == "Great"
+        assert event.question == "How are you?"
+
+    def test_handle_poll_answer_no_event_on_untracked_poll(self):
+        bus = EventBus()
+        received = []
+
+        async def capture(event):
+            received.append(event)
+
+        bus.subscribe(PollAnswered, capture)
+
+        svc = self._make_service(bus)
+        # Do NOT seed tracker -- poll is unknown
+
+        result = asyncio.get_event_loop().run_until_complete(
+            svc.handle_poll_answer("unknown_poll", user_id=42, selected_option_id=0)
+        )
+
+        assert result is False
+        assert len(received) == 0
+
+    def test_event_includes_mood_types(self):
+        """Mood-type polls should still produce PollAnswered with correct type."""
+        bus = EventBus()
+        received = []
+
+        async def capture(event):
+            received.append(event)
+
+        bus.subscribe(PollAnswered, capture)
+
+        svc = self._make_service(bus)
+        svc._poll_tracker["mood1"] = {
+            "template_id": 2,
+            "chat_id": 200,
+            "sent_at": datetime(2026, 2, 1, 8, 0),
+            "question": "Current mood?",
+            "options": ["Energized", "Calm", "Tired", "Anxious"],
+            "poll_type": "emotion",
+            "poll_category": "health",
+            "message_id": 999,
+            "context_data": {},
+        }
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.flush = AsyncMock()
+
+        with patch(
+            "src.services.poll_service.get_db_session",
+            return_value=mock_session,
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                svc.handle_poll_answer("mood1", user_id=42, selected_option_id=3)
+            )
+
+        assert result is True
+        assert len(received) == 1
+        assert received[0].poll_type == "emotion"
+        assert received[0].selected_option_text == "Anxious"

--- a/tests/test_domain/test_poll_subscribers.py
+++ b/tests/test_domain/test_poll_subscribers.py
@@ -1,0 +1,193 @@
+"""Tests for poll response processing subscriber."""
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from src.domain.events import EventBus, MoodCaptured, PollAnswered
+from src.domain.subscribers import PollResponseProcessor
+
+
+class TestPollResponseProcessor:
+    """Verify subscriber flips processed_for flags on PollResponse rows."""
+
+    def _make_event(self, **overrides) -> PollAnswered:
+        defaults = dict(
+            poll_id="p1",
+            chat_id=100,
+            poll_type="emotion",
+            poll_category="personal",
+            selected_option_id=0,
+            selected_option_text="Happy",
+            question="How are you?",
+            response_id=7,
+            timestamp=datetime(2026, 1, 15, 12, 0),
+        )
+        defaults.update(overrides)
+        return PollAnswered(**defaults)
+
+    # -- trails flag --------------------------------------------------------
+
+    def test_sets_processed_for_trails(self):
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock()
+        mock_session.commit = AsyncMock()
+
+        processor = PollResponseProcessor()
+        event = self._make_event()
+
+        with patch(
+            "src.domain.subscribers.get_db_session",
+            return_value=mock_session,
+        ):
+            asyncio.get_event_loop().run_until_complete(
+                processor.on_poll_answered(event)
+            )
+
+        # Should have executed UPDATE setting processed_for_trails = 1
+        calls = mock_session.execute.call_args_list
+        sql_texts = [str(c[0][0]) for c in calls]
+        assert any("processed_for_trails" in s for s in sql_texts)
+
+    # -- todos flag ---------------------------------------------------------
+
+    def test_sets_processed_for_todos(self):
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock()
+        mock_session.commit = AsyncMock()
+
+        processor = PollResponseProcessor()
+        event = self._make_event()
+
+        with patch(
+            "src.domain.subscribers.get_db_session",
+            return_value=mock_session,
+        ):
+            asyncio.get_event_loop().run_until_complete(
+                processor.on_poll_answered(event)
+            )
+
+        calls = mock_session.execute.call_args_list
+        sql_texts = [str(c[0][0]) for c in calls]
+        assert any("processed_for_todos" in s for s in sql_texts)
+
+    # -- insights flag ------------------------------------------------------
+
+    def test_sets_processed_for_insights(self):
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock()
+        mock_session.commit = AsyncMock()
+
+        processor = PollResponseProcessor()
+        event = self._make_event()
+
+        with patch(
+            "src.domain.subscribers.get_db_session",
+            return_value=mock_session,
+        ):
+            asyncio.get_event_loop().run_until_complete(
+                processor.on_poll_answered(event)
+            )
+
+        calls = mock_session.execute.call_args_list
+        sql_texts = [str(c[0][0]) for c in calls]
+        assert any("processed_for_insights" in s for s in sql_texts)
+
+    # -- mood event ---------------------------------------------------------
+
+    def test_emits_mood_captured_for_emotion_type(self):
+        bus = EventBus()
+        mood_events = []
+
+        async def capture(ev):
+            mood_events.append(ev)
+
+        bus.subscribe(MoodCaptured, capture)
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock()
+        mock_session.commit = AsyncMock()
+
+        processor = PollResponseProcessor(event_bus=bus)
+        event = self._make_event(poll_type="emotion", selected_option_text="Joyful")
+
+        with patch(
+            "src.domain.subscribers.get_db_session",
+            return_value=mock_session,
+        ):
+            asyncio.get_event_loop().run_until_complete(
+                processor.on_poll_answered(event)
+            )
+
+        assert len(mood_events) == 1
+        assert mood_events[0].mood_label == "Joyful"
+        assert mood_events[0].poll_id == "p1"
+
+    def test_no_mood_event_for_non_emotion_type(self):
+        bus = EventBus()
+        mood_events = []
+
+        async def capture(ev):
+            mood_events.append(ev)
+
+        bus.subscribe(MoodCaptured, capture)
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock()
+        mock_session.commit = AsyncMock()
+
+        processor = PollResponseProcessor(event_bus=bus)
+        event = self._make_event(poll_type="energy")
+
+        with patch(
+            "src.domain.subscribers.get_db_session",
+            return_value=mock_session,
+        ):
+            asyncio.get_event_loop().run_until_complete(
+                processor.on_poll_answered(event)
+            )
+
+        assert len(mood_events) == 0
+
+    # -- wiring with EventBus -----------------------------------------------
+
+    def test_register_wires_handler_to_bus(self):
+        bus = EventBus()
+        processor = PollResponseProcessor(event_bus=bus)
+        processor.register(bus)
+
+        # After register, PollAnswered should have the handler
+        assert len(bus._subscribers.get(PollAnswered, [])) == 1
+
+    def test_end_to_end_bus_to_processor(self):
+        """Publish PollAnswered on bus -> processor flips flags."""
+        bus = EventBus()
+        processor = PollResponseProcessor(event_bus=bus)
+        processor.register(bus)
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock()
+        mock_session.commit = AsyncMock()
+
+        event = self._make_event()
+
+        with patch(
+            "src.domain.subscribers.get_db_session",
+            return_value=mock_session,
+        ):
+            asyncio.get_event_loop().run_until_complete(bus.publish(event))
+
+        assert mock_session.execute.call_count >= 1
+        assert mock_session.commit.call_count >= 1


### PR DESCRIPTION
## Summary
- Adds PollAnswered and MoodCaptured domain events with EventBus infrastructure
- Emits PollAnswered from poll_service.handle_poll_answer
- Adds PollResponseProcessor subscriber to flip processed_for flags

## Test plan
- [ ] Verify events are emitted on poll answers
- [ ] Verify subscribers receive and process events
- [ ] Full test suite regression check

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)