### PR TITLE
refactor: Split accountability into domain and app services (#226)

### DIFF
--- a/src/services/accountability_app.py
+++ b/src/services/accountability_app.py
@@ -1,0 +1,353 @@
+"""
+Application-layer accountability service.
+
+Orchestrates domain logic (AccountabilityDomainService) with infrastructure
+(SQLAlchemy repos, TTS synthesis). Extracted from AccountabilityService to
+separate concerns (issue #226).
+"""
+
+import logging
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy import select
+
+from ..core.config import get_config_value
+from ..core.database import get_db_session
+from ..core.i18n import t
+from ..models.tracker import CheckIn, Tracker
+from ..models.user_settings import UserSettings
+from .accountability_domain import (
+    AccountabilityDomainService,
+    get_time_period,
+    strip_voice_tags,
+)
+from .voice_synthesis import synthesize_voice_mp3
+
+logger = logging.getLogger(__name__)
+
+PERSONALITY_CONFIG = get_config_value("accountability.personalities", {})
+
+
+class AccountabilityAppService:
+    """Application service wiring domain logic with DB and TTS."""
+
+    # -- Infrastructure helpers (DB) --
+
+    @staticmethod
+    async def _get_user_settings(user_id: int) -> Optional[UserSettings]:
+        async with get_db_session() as session:
+            result = await session.execute(
+                select(UserSettings).where(UserSettings.user_id == user_id)
+            )
+            return result.scalar_one_or_none()
+
+    @staticmethod
+    async def _get_tracker(tracker_id: int) -> Optional[Tracker]:
+        async with get_db_session() as session:
+            result = await session.execute(
+                select(Tracker).where(Tracker.id == tracker_id)
+            )
+            return result.scalar_one_or_none()
+
+    @staticmethod
+    async def _get_active_trackers(user_id: int) -> List[Tracker]:
+        async with get_db_session() as session:
+            result = await session.execute(
+                select(Tracker).where(
+                    Tracker.user_id == user_id, Tracker.active == True
+                )
+            )
+            return list(result.scalars().all())
+
+    @staticmethod
+    async def _get_streak_from_db(user_id: int, tracker_id: int) -> int:
+        """Fetch check-in dates from DB, delegate streak math to domain."""
+        async with get_db_session() as session:
+            result = await session.execute(
+                select(CheckIn)
+                .where(
+                    CheckIn.user_id == user_id,
+                    CheckIn.tracker_id == tracker_id,
+                    CheckIn.status.in_(["completed", "partial"]),
+                )
+                .order_by(CheckIn.created_at.desc())
+            )
+            check_ins = list(result.scalars().all())
+
+        dates = [ci.created_at for ci in check_ins]
+        return AccountabilityDomainService.calculate_streak(dates, datetime.now())
+
+    @staticmethod
+    async def _count_misses_from_db(user_id: int, tracker_id: int) -> int:
+        """Fetch last check-in from DB, delegate miss counting to domain."""
+        async with get_db_session() as session:
+            tracker_result = await session.execute(
+                select(Tracker).where(Tracker.id == tracker_id)
+            )
+            tracker = tracker_result.scalar_one_or_none()
+
+            if not tracker or tracker.check_frequency != "daily":
+                return 0
+
+            result = await session.execute(
+                select(CheckIn)
+                .where(CheckIn.user_id == user_id, CheckIn.tracker_id == tracker_id)
+                .order_by(CheckIn.created_at.desc())
+                .limit(1)
+            )
+            last_checkin = result.scalar_one_or_none()
+
+        last_dt = last_checkin.created_at if last_checkin else None
+        return AccountabilityDomainService.count_consecutive_misses(
+            last_dt, datetime.now()
+        )
+
+    # -- Infrastructure helpers (TTS) --
+
+    @staticmethod
+    async def _synthesize_voice(
+        message: str, voice: str, emotion: str
+    ) -> bytes:
+        return await synthesize_voice_mp3(message, voice=voice, emotion=emotion)
+
+    # -- Message generation (thin wrappers around i18n + domain) --
+
+    @staticmethod
+    def _generate_message_text(
+        personality: str,
+        tracker_name: str,
+        streak: int = 0,
+        locale: str = "en",
+    ) -> str:
+        """Generate check-in message using i18n templates."""
+        from .accountability_service import _time_greeting
+
+        greeting = _time_greeting(locale=locale)
+        if streak > 0:
+            return t(
+                f"accountability.voice.{personality}.checkin_streak",
+                locale,
+                name=tracker_name,
+                streak=streak,
+                greeting=greeting,
+            )
+        return t(
+            f"accountability.voice.{personality}.checkin",
+            locale,
+            name=tracker_name,
+            greeting=greeting,
+        )
+
+    @staticmethod
+    def _generate_struggle_text(
+        personality: str,
+        tracker_name: str,
+        consecutive_misses: int,
+        locale: str = "en",
+    ) -> str:
+        return t(
+            f"accountability.voice.{personality}.struggle",
+            locale,
+            name=tracker_name,
+            misses=consecutive_misses,
+        )
+
+    @staticmethod
+    def _generate_celebration_text(
+        personality: str,
+        tracker_name: str,
+        milestone: int,
+        enthusiasm: float = 1.0,
+        locale: str = "en",
+    ) -> str:
+        message = t(
+            f"accountability.voice.{personality}.celebration",
+            locale,
+            name=tracker_name,
+            milestone=milestone,
+            next_milestone=milestone * 2,
+        )
+        return AccountabilityDomainService.adjust_celebration_enthusiasm(
+            message, enthusiasm
+        )
+
+    @staticmethod
+    def _resolve_voice(settings: UserSettings, personality_config: dict) -> str:
+        return settings.partner_voice_override or personality_config["voice"]
+
+    @staticmethod
+    def _get_personality_config(personality: str) -> dict:
+        return PERSONALITY_CONFIG.get(personality, PERSONALITY_CONFIG.get("supportive", {}))
+
+    # -- Public orchestration methods --
+
+    @staticmethod
+    async def send_check_in(
+        user_id: int, tracker_id: int
+    ) -> Optional[Tuple[str, bytes]]:
+        """Generate check-in voice message.
+
+        Returns:
+            Tuple of (clean text, MP3 audio bytes) on success, None on failure.
+        """
+        try:
+            settings = await AccountabilityAppService._get_user_settings(user_id)
+            if not settings:
+                logger.warning(f"No settings found for user {user_id}")
+                return None
+
+            tracker = await AccountabilityAppService._get_tracker(tracker_id)
+            if not tracker:
+                logger.warning(f"Tracker {tracker_id} not found")
+                return None
+
+            streak = await AccountabilityAppService._get_streak_from_db(
+                user_id, tracker_id
+            )
+
+            message = AccountabilityAppService._generate_message_text(
+                personality=settings.partner_personality,
+                tracker_name=tracker.name,
+                current_streak=streak,
+            )
+
+            pc = AccountabilityAppService._get_personality_config(
+                settings.partner_personality
+            )
+            voice = AccountabilityAppService._resolve_voice(settings, pc)
+            emotion = pc.get("emotion", "neutral")
+
+            audio_bytes = await AccountabilityAppService._synthesize_voice(
+                message, voice=voice, emotion=emotion
+            )
+
+            clean_text = strip_voice_tags(message)
+            logger.info(
+                f"Generated check-in audio for user {user_id}, "
+                f"tracker {tracker_id} ({len(audio_bytes)} bytes)"
+            )
+            return (clean_text, audio_bytes)
+
+        except Exception as e:
+            logger.error(f"Failed to generate check-in: {e}")
+            return None
+
+    @staticmethod
+    async def check_for_struggles(user_id: int) -> Dict[int, int]:
+        """Check all trackers for consecutive misses.
+
+        Returns:
+            Dict mapping tracker_id -> consecutive_misses (only for struggling).
+        """
+        struggles: Dict[int, int] = {}
+
+        settings = await AccountabilityAppService._get_user_settings(user_id)
+        if not settings:
+            return struggles
+
+        trackers = await AccountabilityAppService._get_active_trackers(user_id)
+
+        miss_counts: Dict[int, int] = {}
+        for tracker in trackers:
+            misses = await AccountabilityAppService._count_misses_from_db(
+                user_id, tracker.id
+            )
+            miss_counts[tracker.id] = misses
+
+        return AccountabilityDomainService.detect_struggles(
+            miss_counts, settings.struggle_threshold
+        )
+
+    @staticmethod
+    async def send_struggle_alert(
+        user_id: int, tracker_id: int, consecutive_misses: int
+    ) -> Optional[Tuple[str, bytes]]:
+        """Generate struggle support voice message.
+
+        Returns:
+            Tuple of (clean text, MP3 audio bytes) on success, None on failure.
+        """
+        try:
+            settings = await AccountabilityAppService._get_user_settings(user_id)
+            if not settings:
+                return None
+
+            tracker = await AccountabilityAppService._get_tracker(tracker_id)
+            if not tracker:
+                return None
+
+            message = AccountabilityAppService._generate_struggle_text(
+                personality=settings.partner_personality,
+                tracker_name=tracker.name,
+                consecutive_misses=consecutive_misses,
+            )
+
+            pc = AccountabilityAppService._get_personality_config(
+                settings.partner_personality
+            )
+            voice = AccountabilityAppService._resolve_voice(settings, pc)
+            emotion = pc.get("emotion", "neutral")
+
+            audio_bytes = await AccountabilityAppService._synthesize_voice(
+                message, voice=voice, emotion=emotion
+            )
+
+            clean_text = strip_voice_tags(message)
+            logger.info(
+                f"Generated struggle alert for user {user_id}, tracker {tracker_id}"
+            )
+            return (clean_text, audio_bytes)
+
+        except Exception as e:
+            logger.error(f"Failed to generate struggle alert: {e}")
+            return None
+
+    @staticmethod
+    async def celebrate_milestone(
+        user_id: int, tracker_id: int, milestone: int
+    ) -> Optional[Tuple[str, bytes]]:
+        """Generate milestone celebration voice message.
+
+        Returns:
+            Tuple of (clean text, MP3 audio bytes) on success, None on failure.
+        """
+        try:
+            settings = await AccountabilityAppService._get_user_settings(user_id)
+            if not settings:
+                return None
+
+            tracker = await AccountabilityAppService._get_tracker(tracker_id)
+            if not tracker:
+                return None
+
+            enthusiasm = AccountabilityDomainService.get_enthusiasm_value(
+                settings.celebration_style
+            )
+
+            message = AccountabilityAppService._generate_celebration_text(
+                personality=settings.partner_personality,
+                tracker_name=tracker.name,
+                milestone=milestone,
+                enthusiasm=enthusiasm,
+            )
+
+            pc = AccountabilityAppService._get_personality_config(
+                settings.partner_personality
+            )
+            voice = AccountabilityAppService._resolve_voice(settings, pc)
+
+            audio_bytes = await AccountabilityAppService._synthesize_voice(
+                message, voice=voice, emotion="cheerful"
+            )
+
+            clean_text = strip_voice_tags(message)
+            logger.info(
+                f"Generated celebration for user {user_id}, "
+                f"tracker {tracker_id}, milestone {milestone}"
+            )
+            return (clean_text, audio_bytes)
+
+        except Exception as e:
+            logger.error(f"Failed to generate celebration: {e}")
+            return None

--- a/src/services/accountability_domain.py
+++ b/src/services/accountability_domain.py
@@ -1,0 +1,151 @@
+"""
+Pure domain logic for accountability partner.
+
+No database, no TTS, no network I/O — only data transformations.
+Extracted from AccountabilityService to separate concerns (issue #226).
+"""
+
+import re
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+
+
+def strip_voice_tags(text: str) -> str:
+    """Remove voice/emotion markup tags for clean text display."""
+    text = re.sub(r"\[.*?\]", "", text)  # [whisper], [cheerful], etc.
+    text = re.sub(r"<\w+>", "", text)  # <sigh>, <chuckle>, etc.
+    return text.strip()
+
+
+def get_time_period(now: datetime) -> str:
+    """Return the time-of-day period for a given datetime."""
+    hour = now.hour
+    if 5 <= hour < 12:
+        return "morning"
+    elif 12 <= hour < 17:
+        return "afternoon"
+    elif 17 <= hour < 22:
+        return "evening"
+    else:
+        return "night"
+
+
+class AccountabilityDomainService:
+    """Pure domain logic for accountability tracking.
+
+    All methods are static and accept plain data — no ORM objects required.
+    """
+
+    @staticmethod
+    def calculate_streak(
+        checkin_dates: List[datetime], now: datetime
+    ) -> int:
+        """Calculate current streak from a list of check-in timestamps.
+
+        Args:
+            checkin_dates: Datetimes of completed/partial check-ins (any order).
+            now: Current datetime to measure from.
+
+        Returns:
+            Number of consecutive days with check-ins ending at today.
+        """
+        if not checkin_dates:
+            return 0
+
+        # Deduplicate to unique dates, sorted descending
+        unique_dates = sorted(
+            {d.date() for d in checkin_dates}, reverse=True
+        )
+
+        today = now.date()
+        if unique_dates[0] != today:
+            return 0
+
+        streak = 0
+        expected = today
+        for d in unique_dates:
+            if d == expected:
+                streak += 1
+                expected -= timedelta(days=1)
+            elif d < expected:
+                break
+
+        return streak
+
+    @staticmethod
+    def count_consecutive_misses(
+        last_checkin: Optional[datetime], now: datetime
+    ) -> int:
+        """Count consecutive days without check-ins.
+
+        Args:
+            last_checkin: Datetime of most recent check-in, or None if never.
+            now: Current datetime.
+
+        Returns:
+            Number of days since last check-in. 0 if never checked in or today.
+        """
+        if last_checkin is None:
+            return 0
+
+        days_since = (now - last_checkin).days
+        return max(0, days_since)
+
+    @staticmethod
+    def detect_struggles(
+        miss_counts: Dict[int, int], threshold: int
+    ) -> Dict[int, int]:
+        """Filter trackers that meet or exceed the struggle threshold.
+
+        Args:
+            miss_counts: Mapping of tracker_id -> consecutive miss count.
+            threshold: Minimum misses to qualify as struggling.
+
+        Returns:
+            Subset of miss_counts where count >= threshold.
+        """
+        return {
+            tracker_id: count
+            for tracker_id, count in miss_counts.items()
+            if count >= threshold
+        }
+
+    @staticmethod
+    def adjust_celebration_enthusiasm(message: str, enthusiasm: float) -> str:
+        """Adjust celebration message based on enthusiasm level.
+
+        Args:
+            message: Raw celebration message.
+            enthusiasm: Float level (< 0.7 = quiet, > 1.3 = enthusiastic).
+
+        Returns:
+            Adjusted message.
+        """
+        if enthusiasm < 0.7:
+            message = (
+                message.replace("\U0001f389 ", "")
+                .replace("!", ".")
+                .replace("<laugh>", "")
+                .replace("<chuckle>", "")
+            )
+        elif enthusiasm > 1.3:
+            message = message + " \U0001f525"
+
+        return message
+
+    @staticmethod
+    def get_enthusiasm_value(celebration_style: str) -> float:
+        """Map celebration style name to enthusiasm float.
+
+        Args:
+            celebration_style: One of 'quiet', 'moderate', 'enthusiastic'.
+
+        Returns:
+            Float enthusiasm value.
+        """
+        mapping = {
+            "quiet": 0.5,
+            "moderate": 1.0,
+            "enthusiastic": 2.0,
+        }
+        return mapping.get(celebration_style, 1.0)

--- a/src/services/accountability_scheduler.py
+++ b/src/services/accountability_scheduler.py
@@ -158,11 +158,10 @@ async def send_checkin_reminder(context) -> None:
         # Voice check-in (only if accountability partner enabled)
         if await _is_accountability_enabled(chat_id):
             try:
-                from .accountability_service import AccountabilityService
+                from .accountability_app import AccountabilityAppService
 
-                svc = AccountabilityService()
                 for tracker, streak in unchecked:
-                    result = await svc.send_check_in(
+                    result = await AccountabilityAppService.send_check_in(
                         user_id, tracker.id
                     )
                     if result:
@@ -192,16 +191,15 @@ async def check_struggles(context) -> None:
         return
 
     try:
-        from .accountability_service import AccountabilityService
+        from .accountability_app import AccountabilityAppService
 
-        svc = AccountabilityService()
-        struggles = await AccountabilityService.check_for_struggles(user_id)
+        struggles = await AccountabilityAppService.check_for_struggles(user_id)
 
         if not struggles:
             return
 
         for tracker_id, misses in struggles.items():
-            result = await svc.send_struggle_alert(
+            result = await AccountabilityAppService.send_struggle_alert(
                 user_id, tracker_id, misses
             )
             if result:
@@ -241,7 +239,7 @@ async def check_struggles(context) -> None:
                     if not tracker:
                         continue
 
-                    msg = AccountabilityService.generate_struggle_message(
+                    msg = AccountabilityAppService._generate_struggle_text(
                         personality=personality,
                         tracker_name=tracker.name,
                         consecutive_misses=misses,
@@ -262,9 +260,7 @@ async def check_struggles(context) -> None:
         logger.error(f"Error checking struggles for user {user_id}: {e}")
 
 
-async def schedule_user_checkins(
-    application: Any, user_id: int, chat_id: int
-) -> None:
+async def schedule_user_checkins(application: Any, user_id: int, chat_id: int) -> None:
     """Schedule daily check-in and struggle-check jobs for a user."""
     try:
         async with get_db_session() as session:

--- a/tests/test_accountability_app.py
+++ b/tests/test_accountability_app.py
@@ -1,0 +1,288 @@
+"""
+Tests for AccountabilityAppService — application-layer orchestration.
+
+Uses mocks for DB queries (repos) and TTS. Verifies the app service
+correctly wires domain logic with infrastructure.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_settings(**overrides):
+    """Create a mock UserSettings with defaults."""
+    s = MagicMock()
+    s.partner_personality = overrides.get("partner_personality", "supportive")
+    s.partner_voice_override = overrides.get("partner_voice_override", None)
+    s.struggle_threshold = overrides.get("struggle_threshold", 3)
+    s.celebration_style = overrides.get("celebration_style", "moderate")
+    return s
+
+
+def _make_tracker(**overrides):
+    """Create a mock Tracker."""
+    t = MagicMock()
+    t.id = overrides.get("id", 1)
+    t.name = overrides.get("name", "Exercise")
+    t.check_frequency = overrides.get("check_frequency", "daily")
+    t.active = overrides.get("active", True)
+    return t
+
+
+def _make_checkin(created_at, status="completed"):
+    """Create a mock CheckIn."""
+    ci = MagicMock()
+    ci.created_at = created_at
+    ci.status = status
+    return ci
+
+
+class TestAppServiceSendCheckIn:
+    """Test send_check_in orchestration."""
+
+    @pytest.mark.asyncio
+    async def test_send_check_in_returns_text_and_audio(self):
+        from src.services.accountability_app import AccountabilityAppService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        settings = _make_settings()
+        tracker = _make_tracker(name="Meditation")
+
+        with (
+            patch.object(
+                AccountabilityAppService,
+                "_get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_get_tracker",
+                new_callable=AsyncMock,
+                return_value=tracker,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_get_streak_from_db",
+                new_callable=AsyncMock,
+                return_value=5,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_generate_message_text",
+                return_value="Check in on Meditation. 5 days strong!",
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_synthesize_voice",
+                new_callable=AsyncMock,
+                return_value=b"fake-audio-bytes",
+            ),
+        ):
+            result = await AccountabilityAppService.send_check_in(
+                user_id=123, tracker_id=1
+            )
+
+        assert result is not None
+        text, audio = result
+        assert "Meditation" in text
+        assert audio == b"fake-audio-bytes"
+
+    @pytest.mark.asyncio
+    async def test_send_check_in_no_settings_returns_none(self):
+        from src.services.accountability_app import AccountabilityAppService
+
+        with patch.object(
+            AccountabilityAppService,
+            "_get_user_settings",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await AccountabilityAppService.send_check_in(
+                user_id=123, tracker_id=1
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_send_check_in_no_tracker_returns_none(self):
+        from src.services.accountability_app import AccountabilityAppService
+
+        settings = _make_settings()
+        with (
+            patch.object(
+                AccountabilityAppService,
+                "_get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_get_tracker",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await AccountabilityAppService.send_check_in(
+                user_id=123, tracker_id=1
+            )
+
+        assert result is None
+
+
+class TestAppServiceCheckForStruggles:
+    """Test check_for_struggles orchestration."""
+
+    @pytest.mark.asyncio
+    async def test_returns_struggles_above_threshold(self):
+        from src.services.accountability_app import AccountabilityAppService
+
+        settings = _make_settings(struggle_threshold=3)
+        trackers = [
+            _make_tracker(id=1, name="Exercise"),
+            _make_tracker(id=2, name="Reading"),
+        ]
+
+        with (
+            patch.object(
+                AccountabilityAppService,
+                "_get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_get_active_trackers",
+                new_callable=AsyncMock,
+                return_value=trackers,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_count_misses_from_db",
+                new_callable=AsyncMock,
+                side_effect=[4, 1],  # Exercise=4 misses, Reading=1
+            ),
+        ):
+            result = await AccountabilityAppService.check_for_struggles(user_id=123)
+
+        assert result == {1: 4}
+
+    @pytest.mark.asyncio
+    async def test_no_settings_returns_empty(self):
+        from src.services.accountability_app import AccountabilityAppService
+
+        with patch.object(
+            AccountabilityAppService,
+            "_get_user_settings",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await AccountabilityAppService.check_for_struggles(user_id=123)
+
+        assert result == {}
+
+
+class TestAppServiceSendStruggleAlert:
+    """Test send_struggle_alert orchestration."""
+
+    @pytest.mark.asyncio
+    async def test_returns_text_and_audio(self):
+        from src.services.accountability_app import AccountabilityAppService
+
+        settings = _make_settings()
+        tracker = _make_tracker(name="Exercise")
+
+        with (
+            patch.object(
+                AccountabilityAppService,
+                "_get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_get_tracker",
+                new_callable=AsyncMock,
+                return_value=tracker,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_generate_struggle_text",
+                return_value="Missed 5 days on Exercise.",
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_synthesize_voice",
+                new_callable=AsyncMock,
+                return_value=b"audio-bytes",
+            ),
+        ):
+            result = await AccountabilityAppService.send_struggle_alert(
+                user_id=123, tracker_id=1, consecutive_misses=5
+            )
+
+        assert result is not None
+        text, audio = result
+        assert "Exercise" in text
+        assert audio == b"audio-bytes"
+
+
+class TestAppServiceCelebrateMilestone:
+    """Test celebrate_milestone orchestration."""
+
+    @pytest.mark.asyncio
+    async def test_returns_text_and_audio(self):
+        from src.services.accountability_app import AccountabilityAppService
+
+        settings = _make_settings(celebration_style="enthusiastic")
+        tracker = _make_tracker(name="Meditation")
+
+        with (
+            patch.object(
+                AccountabilityAppService,
+                "_get_user_settings",
+                new_callable=AsyncMock,
+                return_value=settings,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_get_tracker",
+                new_callable=AsyncMock,
+                return_value=tracker,
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_generate_celebration_text",
+                return_value="7-day streak! Amazing! 🔥",
+            ),
+            patch.object(
+                AccountabilityAppService,
+                "_synthesize_voice",
+                new_callable=AsyncMock,
+                return_value=b"celebration-audio",
+            ),
+        ):
+            result = await AccountabilityAppService.celebrate_milestone(
+                user_id=123, tracker_id=1, milestone=7
+            )
+
+        assert result is not None
+        text, audio = result
+        assert audio == b"celebration-audio"
+
+
+class TestAppServiceDelegation:
+    """Verify app service delegates to domain service for pure logic."""
+
+    def test_get_streak_from_db_uses_domain_calculate_streak(self):
+        """Confirm the app service method signature exists and is async."""
+        from src.services.accountability_app import AccountabilityAppService
+
+        assert hasattr(AccountabilityAppService, "_get_streak_from_db")
+
+    def test_count_misses_from_db_exists(self):
+        from src.services.accountability_app import AccountabilityAppService
+
+        assert hasattr(AccountabilityAppService, "_count_misses_from_db")

--- a/tests/test_accountability_domain.py
+++ b/tests/test_accountability_domain.py
@@ -1,0 +1,244 @@
+"""
+Tests for AccountabilityDomainService — pure domain logic with no DB or TTS.
+
+Covers:
+- Streak calculation from check-in date lists
+- Consecutive miss counting
+- Struggle detection against threshold
+- Message generation (check-in, celebration, struggle)
+- Voice tag stripping
+- Time-based greeting periods
+- Enthusiasm-based celebration adjustments
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+
+class TestStreakCalculation:
+    """Streak counting from a list of check-in dates."""
+
+    def test_no_checkins_returns_zero(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        assert AccountabilityDomainService.calculate_streak([], datetime.now()) == 0
+
+    def test_single_today_checkin(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        dates = [now.replace(hour=9)]
+        assert AccountabilityDomainService.calculate_streak(dates, now) == 1
+
+    def test_consecutive_days_streak(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        dates = [
+            now - timedelta(days=2),
+            now - timedelta(days=1),
+            now,
+        ]
+        assert AccountabilityDomainService.calculate_streak(dates, now) == 3
+
+    def test_gap_breaks_streak(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        # Checked in today and 3 days ago, but not yesterday
+        dates = [
+            now - timedelta(days=3),
+            now,
+        ]
+        assert AccountabilityDomainService.calculate_streak(dates, now) == 1
+
+    def test_no_checkin_today_zero_streak(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        # Last check-in was yesterday
+        dates = [now - timedelta(days=1)]
+        assert AccountabilityDomainService.calculate_streak(dates, now) == 0
+
+    def test_multiple_checkins_same_day_count_once(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        dates = [
+            now - timedelta(days=1, hours=2),
+            now - timedelta(days=1, hours=5),
+            now.replace(hour=8),
+            now.replace(hour=12),
+        ]
+        assert AccountabilityDomainService.calculate_streak(dates, now) == 2
+
+    def test_unsorted_dates_handled(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        # Dates not in order
+        dates = [
+            now,
+            now - timedelta(days=2),
+            now - timedelta(days=1),
+        ]
+        assert AccountabilityDomainService.calculate_streak(dates, now) == 3
+
+
+class TestConsecutiveMisses:
+    """Count consecutive days without check-ins."""
+
+    def test_no_checkins_returns_zero(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        assert (
+            AccountabilityDomainService.count_consecutive_misses(None, datetime.now())
+            == 0
+        )
+
+    def test_checkin_today_zero_misses(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        last_checkin = now.replace(hour=9)
+        assert (
+            AccountabilityDomainService.count_consecutive_misses(last_checkin, now) == 0
+        )
+
+    def test_checkin_yesterday_one_miss(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        last_checkin = now - timedelta(days=1)
+        assert (
+            AccountabilityDomainService.count_consecutive_misses(last_checkin, now) == 1
+        )
+
+    def test_checkin_five_days_ago(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        now = datetime(2026, 2, 19, 14, 0)
+        last_checkin = now - timedelta(days=5)
+        assert (
+            AccountabilityDomainService.count_consecutive_misses(last_checkin, now) == 5
+        )
+
+
+class TestStruggleDetection:
+    """Detect struggles from miss counts vs threshold."""
+
+    def test_no_struggles_under_threshold(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        # tracker_id -> miss_count, threshold = 3
+        miss_counts = {1: 1, 2: 2, 3: 0}
+        result = AccountabilityDomainService.detect_struggles(miss_counts, threshold=3)
+        assert result == {}
+
+    def test_struggles_at_threshold(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        miss_counts = {1: 3, 2: 5}
+        result = AccountabilityDomainService.detect_struggles(miss_counts, threshold=3)
+        assert result == {1: 3, 2: 5}
+
+    def test_mixed_above_and_below(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        miss_counts = {1: 2, 2: 4, 3: 1, 4: 3}
+        result = AccountabilityDomainService.detect_struggles(miss_counts, threshold=3)
+        assert result == {2: 4, 4: 3}
+
+
+class TestStripVoiceTags:
+    """Test removal of voice/emotion markup."""
+
+    def test_strip_bracket_tags(self):
+        from src.services.accountability_domain import strip_voice_tags
+
+        assert strip_voice_tags("[whisper]Hello[/whisper]") == "Hello"
+
+    def test_strip_angle_tags(self):
+        from src.services.accountability_domain import strip_voice_tags
+
+        assert strip_voice_tags("<sigh>Oh well") == "Oh well"
+
+    def test_strip_mixed_tags(self):
+        from src.services.accountability_domain import strip_voice_tags
+
+        result = strip_voice_tags("[cheerful]Great job!<chuckle>")
+        assert result == "Great job!"
+
+    def test_no_tags_unchanged(self):
+        from src.services.accountability_domain import strip_voice_tags
+
+        assert strip_voice_tags("Plain text here") == "Plain text here"
+
+
+class TestTimeGreeting:
+    """Test time-of-day greeting selection."""
+
+    def test_morning_greeting(self):
+        from src.services.accountability_domain import get_time_period
+
+        assert get_time_period(datetime(2026, 2, 19, 8, 0)) == "morning"
+
+    def test_afternoon_greeting(self):
+        from src.services.accountability_domain import get_time_period
+
+        assert get_time_period(datetime(2026, 2, 19, 14, 0)) == "afternoon"
+
+    def test_evening_greeting(self):
+        from src.services.accountability_domain import get_time_period
+
+        assert get_time_period(datetime(2026, 2, 19, 19, 0)) == "evening"
+
+    def test_night_greeting(self):
+        from src.services.accountability_domain import get_time_period
+
+        assert get_time_period(datetime(2026, 2, 19, 23, 0)) == "night"
+
+    def test_boundary_5am_is_morning(self):
+        from src.services.accountability_domain import get_time_period
+
+        assert get_time_period(datetime(2026, 2, 19, 5, 0)) == "morning"
+
+    def test_boundary_4am_is_night(self):
+        from src.services.accountability_domain import get_time_period
+
+        assert get_time_period(datetime(2026, 2, 19, 4, 0)) == "night"
+
+
+class TestCelebrationEnthusiasm:
+    """Test enthusiasm adjustment on celebration messages."""
+
+    def test_quiet_removes_emoji_and_exclamation(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        msg = "🎉 7-day streak! Amazing!"
+        result = AccountabilityDomainService.adjust_celebration_enthusiasm(msg, 0.5)
+        assert "🎉" not in result
+        assert "!" not in result
+
+    def test_enthusiastic_adds_fire(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        msg = "7-day streak! Amazing!"
+        result = AccountabilityDomainService.adjust_celebration_enthusiasm(msg, 1.5)
+        assert result.endswith("🔥")
+
+    def test_moderate_unchanged(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        msg = "7-day streak! Amazing!"
+        result = AccountabilityDomainService.adjust_celebration_enthusiasm(msg, 1.0)
+        assert result == msg
+
+    def test_enthusiasm_mapping(self):
+        from src.services.accountability_domain import AccountabilityDomainService
+
+        assert AccountabilityDomainService.get_enthusiasm_value("quiet") == 0.5
+        assert AccountabilityDomainService.get_enthusiasm_value("moderate") == 1.0
+        assert AccountabilityDomainService.get_enthusiasm_value("enthusiastic") == 2.0
+        assert AccountabilityDomainService.get_enthusiasm_value("unknown") == 1.0

--- a/tests/test_scheduler_uses_app_service.py
+++ b/tests/test_scheduler_uses_app_service.py
@@ -1,0 +1,139 @@
+"""
+Tests verifying accountability_scheduler uses AccountabilityAppService
+instead of the old AccountabilityService.
+
+Slice 3: After updating the scheduler imports, these confirm the
+new wiring is correct.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestSchedulerImportsAppService:
+    """Verify scheduler references AccountabilityAppService."""
+
+    def test_send_checkin_reminder_imports_app_service(self):
+        """The send_checkin_reminder function should import from accountability_app."""
+        import inspect
+
+        from src.services.accountability_scheduler import send_checkin_reminder
+
+        source = inspect.getsource(send_checkin_reminder)
+        assert "AccountabilityAppService" in source
+        assert "accountability_app" in source
+
+    def test_check_struggles_imports_app_service(self):
+        """The check_struggles function should import from accountability_app."""
+        import inspect
+
+        from src.services.accountability_scheduler import check_struggles
+
+        source = inspect.getsource(check_struggles)
+        assert "AccountabilityAppService" in source
+        assert "accountability_app" in source
+
+    def test_check_struggles_fallback_imports_app_service(self):
+        """The fallback message gen in check_struggles should use app service."""
+        import inspect
+
+        from src.services.accountability_scheduler import check_struggles
+
+        source = inspect.getsource(check_struggles)
+        # Should NOT import the old AccountabilityService
+        assert "from .accountability_service import AccountabilityService" not in source
+
+
+class TestSchedulerCallsAppService:
+    """Verify the scheduler delegates to AccountabilityAppService methods."""
+
+    @pytest.mark.asyncio
+    async def test_send_checkin_calls_app_send_check_in(self):
+        """send_checkin_reminder should call AccountabilityAppService.send_check_in."""
+        from src.services.accountability_scheduler import send_checkin_reminder
+
+        context = MagicMock()
+        context.job = MagicMock()
+        context.job.data = {"user_id": 123, "chat_id": 456, "locale": "en"}
+        context.bot.send_message = AsyncMock()
+        context.bot.send_voice = AsyncMock()
+
+        mock_tracker = MagicMock()
+        mock_tracker.id = 1
+        mock_tracker.name = "Exercise"
+        mock_tracker.type = "habit"
+
+        with (
+            patch(
+                "src.services.accountability_scheduler._is_quiet_hours",
+                return_value=False,
+            ),
+            patch(
+                "src.services.accountability_scheduler.get_db_session"
+            ) as mock_db,
+            patch(
+                "src.services.tracker_queries.get_today_checkin",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "src.services.tracker_queries.get_streak",
+                new_callable=AsyncMock,
+                return_value=3,
+            ),
+            patch(
+                "src.services.accountability_scheduler._is_accountability_enabled",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "src.services.accountability_app.AccountabilityAppService.send_check_in",
+                new_callable=AsyncMock,
+                return_value=("Check in!", b"audio"),
+            ) as mock_send,
+        ):
+            mock_session = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.scalars.return_value.all.return_value = [mock_tracker]
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+            mock_db.return_value = mock_session
+
+            await send_checkin_reminder(context)
+
+            mock_send.assert_called_once_with(123, 1)
+
+    @pytest.mark.asyncio
+    async def test_check_struggles_calls_app_service(self):
+        """check_struggles should call AccountabilityAppService methods."""
+        from src.services.accountability_scheduler import check_struggles
+
+        context = MagicMock()
+        context.job = MagicMock()
+        context.job.data = {"user_id": 123, "chat_id": 456}
+        context.bot.send_message = AsyncMock()
+        context.bot.send_voice = AsyncMock()
+
+        with (
+            patch(
+                "src.services.accountability_scheduler._is_accountability_enabled",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "src.services.accountability_app.AccountabilityAppService.check_for_struggles",
+                new_callable=AsyncMock,
+                return_value={1: 5},
+            ) as mock_struggles,
+            patch(
+                "src.services.accountability_app.AccountabilityAppService.send_struggle_alert",
+                new_callable=AsyncMock,
+                return_value=("You missed 5 days", b"audio"),
+            ) as mock_alert,
+        ):
+            await check_struggles(context)
+
+            mock_struggles.assert_called_once_with(123)
+            mock_alert.assert_called_once_with(123, 1, 5)


### PR DESCRIPTION
## Summary
- Extracts AccountabilityDomainService with pure domain logic (no I/O)
- Adds AccountabilityAppService wrapping domain + DB + TTS orchestration
- Updates scheduler to use the new app service layer

## Test plan
- [ ] Verify domain service has no infrastructure imports
- [ ] Test app service orchestrates correctly
- [ ] Full test suite regression check

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)