### PR TITLE
fix: sanitize API error responses (#213)

### DIFF
--- a/src/api/webhook.py
+++ b/src/api/webhook.py
@@ -189,11 +189,13 @@ async def update_webhook(
                 detail=f"Failed to update webhook: {message}",
             )
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error updating webhook: {e}")
+        logger.error("Error updating webhook: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Internal error updating webhook: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -228,11 +230,13 @@ async def refresh_webhook(
             logger.error(f"Failed to refresh webhook via API: {message}")
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error refreshing webhook: {e}")
+        logger.error("Error refreshing webhook: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Internal error refreshing webhook: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -268,11 +272,13 @@ async def get_webhook_status(
             active=active,
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error getting webhook status: {e}")
+        logger.error("Error getting webhook status: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Internal error getting webhook status: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -290,11 +296,13 @@ async def delete_webhook(
         else:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error deleting webhook: {e}")
+        logger.error("Error deleting webhook: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Internal error deleting webhook: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -316,11 +324,13 @@ async def start_ngrok_tunnel(
             webhook_url=public_url,
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error starting ngrok tunnel: {e}")
+        logger.error("Error starting ngrok tunnel: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to start ngrok tunnel: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -334,11 +344,13 @@ async def stop_ngrok_tunnel() -> WebhookResponse:
             success=True, message="ngrok tunnel stopped successfully"
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error stopping ngrok tunnel: {e}")
+        logger.error("Error stopping ngrok tunnel: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to stop ngrok tunnel: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -348,9 +360,11 @@ async def get_ngrok_tunnels() -> Dict:
         tunnels = await NgrokManager.get_ngrok_api_tunnels()
         return {"tunnels": tunnels}
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error getting ngrok tunnels: {e}")
+        logger.error("Error getting ngrok tunnels: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to get ngrok tunnels: {str(e)}",
+            detail="Internal server error",
         )

--- a/tests/test_api/test_webhook_error_sanitization.py
+++ b/tests/test_api/test_webhook_error_sanitization.py
@@ -1,0 +1,220 @@
+"""Tests that API error responses do not expose internal exception details.
+
+Issue #213: HTTPException details included str(e), leaking internal info.
+"""
+
+import hashlib
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Set test environment before importing app
+os.environ["TELEGRAM_WEBHOOK_SECRET"] = "test_webhook_secret_12345"
+os.environ["TELEGRAM_BOT_TOKEN"] = "test:bot_token"
+
+
+def get_test_admin_api_key() -> str:
+    """Generate the expected admin API key for tests (legacy derivation)."""
+    secret = os.environ["TELEGRAM_WEBHOOK_SECRET"]
+    return hashlib.sha256(f"{secret}:admin_api".encode()).hexdigest()
+
+
+# A distinctive string that should never appear in HTTP responses
+SECRET_EXCEPTION_MSG = "SUPER_SECRET_DB_PASSWORD_leak_1234"
+
+
+class TestWebhookErrorSanitization:
+    """Webhook management endpoints must not expose exception details."""
+
+    @pytest.fixture
+    def client(self):
+        """Create test client with mocked dependencies."""
+        with (
+            patch("src.lifecycle.initialize_bot", new_callable=AsyncMock),
+            patch("src.lifecycle.shutdown_bot", new_callable=AsyncMock),
+            patch("src.lifecycle.init_database", new_callable=AsyncMock),
+            patch("src.lifecycle.close_database", new_callable=AsyncMock),
+            patch("src.lifecycle.setup_services"),
+            patch("src.lifecycle.get_plugin_manager") as mock_pm,
+            patch("src.main.get_bot") as mock_get_bot,
+        ):
+            mock_pm_instance = MagicMock()
+            mock_pm_instance.load_plugins = AsyncMock(return_value={})
+            mock_pm_instance.activate_plugins = AsyncMock()
+            mock_pm_instance.shutdown = AsyncMock()
+            mock_pm.return_value = mock_pm_instance
+
+            mock_bot = MagicMock()
+            mock_bot.application = MagicMock()
+            mock_get_bot.return_value = mock_bot
+
+            from fastapi.testclient import TestClient
+
+            from src.main import app
+
+            with TestClient(app, raise_server_exceptions=False) as client:
+                yield client
+
+    @pytest.fixture
+    def admin_headers(self):
+        """Return headers with valid admin API key."""
+        return {"X-Api-Key": get_test_admin_api_key()}
+
+    # -- /admin/webhook/update (500 path) --
+
+    def test_update_webhook_500_hides_exception(self, client, admin_headers):
+        """POST /admin/webhook/update: 500 must not contain exception text."""
+        with patch("src.api.webhook.WebhookManager") as mock_wm:
+            mock_wm.side_effect = RuntimeError(SECRET_EXCEPTION_MSG)
+
+            response = client.post(
+                "/admin/webhook/update",
+                headers=admin_headers,
+                json={"url": "https://example.com/webhook"},
+            )
+
+        assert response.status_code == 500
+        detail = response.json().get("detail", "")
+        assert SECRET_EXCEPTION_MSG not in detail
+
+    # -- /admin/webhook/refresh (500 path) --
+
+    def test_refresh_webhook_500_hides_exception(self, client, admin_headers):
+        """POST /admin/webhook/refresh: 500 must not contain exception text."""
+        with patch(
+            "src.api.webhook.auto_update_webhook_on_restart",
+            new_callable=AsyncMock,
+        ) as mock_auto:
+            mock_auto.side_effect = RuntimeError(SECRET_EXCEPTION_MSG)
+
+            response = client.post(
+                "/admin/webhook/refresh",
+                headers=admin_headers,
+                json={"port": 8000, "webhook_path": "/webhook"},
+            )
+
+        assert response.status_code == 500
+        detail = response.json().get("detail", "")
+        assert SECRET_EXCEPTION_MSG not in detail
+
+    # -- /admin/webhook/status (500 path) --
+
+    def test_get_status_500_hides_exception(self, client, admin_headers):
+        """GET /admin/webhook/status: 500 must not contain exception text."""
+        with patch("src.api.webhook.WebhookManager") as mock_wm:
+            mock_wm.side_effect = RuntimeError(SECRET_EXCEPTION_MSG)
+
+            response = client.get(
+                "/admin/webhook/status",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 500
+        detail = response.json().get("detail", "")
+        assert SECRET_EXCEPTION_MSG not in detail
+
+    # -- /admin/webhook/ DELETE (500 path) --
+
+    def test_delete_webhook_500_hides_exception(self, client, admin_headers):
+        """DELETE /admin/webhook/: 500 must not contain exception text."""
+        with patch("src.api.webhook.WebhookManager") as mock_wm:
+            mock_wm.side_effect = RuntimeError(SECRET_EXCEPTION_MSG)
+
+            response = client.delete(
+                "/admin/webhook/",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 500
+        detail = response.json().get("detail", "")
+        assert SECRET_EXCEPTION_MSG not in detail
+
+
+class TestNgrokErrorSanitization:
+    """Ngrok endpoints must not expose exception details."""
+
+    @pytest.fixture
+    def client(self):
+        """Create test client with mocked dependencies."""
+        with (
+            patch("src.lifecycle.initialize_bot", new_callable=AsyncMock),
+            patch("src.lifecycle.shutdown_bot", new_callable=AsyncMock),
+            patch("src.lifecycle.init_database", new_callable=AsyncMock),
+            patch("src.lifecycle.close_database", new_callable=AsyncMock),
+            patch("src.lifecycle.setup_services"),
+            patch("src.lifecycle.get_plugin_manager") as mock_pm,
+            patch("src.main.get_bot") as mock_get_bot,
+        ):
+            mock_pm_instance = MagicMock()
+            mock_pm_instance.load_plugins = AsyncMock(return_value={})
+            mock_pm_instance.activate_plugins = AsyncMock()
+            mock_pm_instance.shutdown = AsyncMock()
+            mock_pm.return_value = mock_pm_instance
+
+            mock_bot = MagicMock()
+            mock_bot.application = MagicMock()
+            mock_get_bot.return_value = mock_bot
+
+            from fastapi.testclient import TestClient
+
+            from src.main import app
+
+            with TestClient(app, raise_server_exceptions=False) as client:
+                yield client
+
+    @pytest.fixture
+    def admin_headers(self):
+        """Return headers with valid admin API key."""
+        return {"X-Api-Key": get_test_admin_api_key()}
+
+    # -- /admin/webhook/ngrok/start (500 path) --
+
+    def test_ngrok_start_500_hides_exception(self, client, admin_headers):
+        """POST /admin/webhook/ngrok/start: 500 must not expose exception."""
+        with patch("src.api.webhook.NgrokManager") as mock_ng:
+            mock_ng.side_effect = RuntimeError(SECRET_EXCEPTION_MSG)
+
+            response = client.post(
+                "/admin/webhook/ngrok/start",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 500
+        detail = response.json().get("detail", "")
+        assert SECRET_EXCEPTION_MSG not in detail
+
+    # -- /admin/webhook/ngrok/stop (500 path) --
+
+    def test_ngrok_stop_500_hides_exception(self, client, admin_headers):
+        """POST /admin/webhook/ngrok/stop: 500 must not expose exception."""
+        with patch("src.api.webhook.NgrokManager") as mock_ng:
+            mock_ng.side_effect = RuntimeError(SECRET_EXCEPTION_MSG)
+
+            response = client.post(
+                "/admin/webhook/ngrok/stop",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 500
+        detail = response.json().get("detail", "")
+        assert SECRET_EXCEPTION_MSG not in detail
+
+    # -- /admin/webhook/ngrok/tunnels (500 path) --
+
+    def test_ngrok_tunnels_500_hides_exception(self, client, admin_headers):
+        """GET /admin/webhook/ngrok/tunnels: 500 must not expose exception."""
+        with patch(
+            "src.api.webhook.NgrokManager.get_ngrok_api_tunnels",
+            new_callable=AsyncMock,
+        ) as mock_tunnels:
+            mock_tunnels.side_effect = RuntimeError(SECRET_EXCEPTION_MSG)
+
+            response = client.get(
+                "/admin/webhook/ngrok/tunnels",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 500
+        detail = response.json().get("detail", "")
+        assert SECRET_EXCEPTION_MSG not in detail


### PR DESCRIPTION
## Summary
- Replace `detail=f"...{str(e)}"` with generic "Internal server error" in all 7 webhook/ngrok endpoint exception handlers
- Add `except HTTPException: raise` before generic catch to preserve intentional 400 responses
- Log full tracebacks via `logger.error(..., exc_info=True)` instead of leaking to HTTP response

## Test plan
- [x] 7 new tests verify sensitive strings don't appear in HTTP response detail
- [x] Pre-existing test suite unaffected

Closes #213

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>